### PR TITLE
Implement DAO layer for Roles

### DIFF
--- a/kratos/src/main/java/com/heimdallauth/server/dao/RoleDataManagerMongoImpl.java
+++ b/kratos/src/main/java/com/heimdallauth/server/dao/RoleDataManagerMongoImpl.java
@@ -1,0 +1,70 @@
+package com.heimdallauth.server.dao;
+
+import com.heimdallauth.server.commons.models.RoleModel;
+import com.heimdallauth.server.datamanagers.RoleDataManager;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.stereotype.Repository;
+
+import java.time.Instant;
+import java.util.Optional;
+
+@Repository
+@Slf4j
+public class RoleDataManagerMongoImpl implements RoleDataManager {
+    private static final String ROLES_COLLECTION = "role-collection";
+    private final MongoTemplate mongoTemplate;
+
+    public RoleDataManagerMongoImpl(MongoTemplate mongoTemplate) {
+        this.mongoTemplate = mongoTemplate;
+    }
+    private static RoleDocument convertToRoleDocument(RoleModel roleModel){
+        return RoleDocument.builder()
+                .id(roleModel.getId())
+                .roleName(roleModel.getRoleName())
+                .roleDescription(roleModel.getRoleDescription())
+                .createdOn(roleModel.getCreatedOn())
+                .lastUpdatedOn(roleModel.getLastUpdatedOn())
+                .build();
+    }
+    private static RoleModel convertToRoleModel(RoleDocument roleDocument){
+        return RoleModel.builder()
+                .id(roleDocument.getId())
+                .roleName(roleDocument.getRoleName())
+                .roleDescription(roleDocument.getRoleDescription())
+                .createdOn(roleDocument.getCreatedOn())
+                .lastUpdatedOn(roleDocument.getLastUpdatedOn())
+                .build();
+    }
+
+    @Override
+    public RoleModel createRole(String roleName, String roleDescription) {
+        RoleDocument roleDocumentToSave = RoleDocument.builder()
+                .roleName(roleName)
+                .roleDescription(roleDescription)
+                .createdOn(Instant.now())
+                .lastUpdatedOn(Instant.now())
+                .build();
+        RoleDocument savedRoleDocument = mongoTemplate.save(roleDocumentToSave, ROLES_COLLECTION);
+        return convertToRoleModel(savedRoleDocument);
+    }
+
+    @Override
+    public Optional<RoleModel> getRole(String roleId) {
+        Query selectRoleFromId = Query.query(Criteria.where("id").is(roleId));
+        return Optional.ofNullable(mongoTemplate.findOne(selectRoleFromId, RoleDocument.class, ROLES_COLLECTION)).map(RoleDataManagerMongoImpl::convertToRoleModel);
+    }
+
+    @Override
+    public Optional<RoleModel> searchRoleUsingRoleNameOrRoleDescription(String searchTerm) {
+        Query searchQuery = Query.query(Criteria.where("roleName").regex(searchTerm, "i").orOperator(Criteria.where("roleDescription").regex(searchTerm,"i")));
+        return Optional.ofNullable(mongoTemplate.findOne(searchQuery, RoleDocument.class, ROLES_COLLECTION)).map(RoleDataManagerMongoImpl::convertToRoleModel);
+    }
+
+    @Override
+    public Optional<RoleModel> updateRole(String roleId, String roleName, String roleDescription) {
+        return Optional.empty();
+    }
+}

--- a/kratos/src/main/java/com/heimdallauth/server/dao/RoleDocument.java
+++ b/kratos/src/main/java/com/heimdallauth/server/dao/RoleDocument.java
@@ -1,0 +1,22 @@
+package com.heimdallauth.server.dao;
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.Instant;
+
+@Document
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class RoleDocument {
+    @Id
+    private String id;
+    private String roleName;
+    private String roleDescription;
+    private Instant createdOn;
+    private Instant lastUpdatedOn;
+}

--- a/kratos/src/main/java/com/heimdallauth/server/datamanagers/RoleDataManager.java
+++ b/kratos/src/main/java/com/heimdallauth/server/datamanagers/RoleDataManager.java
@@ -1,0 +1,12 @@
+package com.heimdallauth.server.datamanagers;
+
+import com.heimdallauth.server.commons.models.RoleModel;
+
+import java.util.Optional;
+
+public interface RoleDataManager {
+    RoleModel createRole(String roleName, String roleDescription);
+    Optional<RoleModel> getRole(String roleId);
+    Optional<RoleModel> searchRoleUsingRoleNameOrRoleDescription(String searchTerm);
+    Optional<RoleModel> updateRole(String roleId, String roleName, String roleDescription);
+}


### PR DESCRIPTION
This pull request introduces a new implementation for managing role data using MongoDB. The changes include the creation of a new data manager class, a document class for roles, and an interface for the data manager.

### New MongoDB Role Data Management:

* [`kratos/src/main/java/com/heimdallauth/server/dao/RoleDataManagerMongoImpl.java`](diffhunk://#diff-4e06ac1730b762ce9a9ec5e5573bf128ddc475faf4ac7246b3685a807c2b1b5cR1-R70): Added a new class `RoleDataManagerMongoImpl` to handle role data operations using MongoDB. This includes methods for creating, retrieving, searching, and updating roles.
* [`kratos/src/main/java/com/heimdallauth/server/dao/RoleDocument.java`](diffhunk://#diff-85cf794d77f22d017e3d50b067266a94af7bbaaf9d3e8bfd1556e30eeb7b0b19R1-R22): Introduced a new `RoleDocument` class to represent the role data structure in MongoDB. This class includes fields for role ID, name, description, creation time, and last update time.
* [`kratos/src/main/java/com/heimdallauth/server/datamanagers/RoleDataManager.java`](diffhunk://#diff-ff78b2dda3dd8ae9408af2050083af66d50bed20c4a94cf5ad4d5a07bd869316R1-R12): Added a new `RoleDataManager` interface to define the contract for role data operations, including methods for creating, retrieving, searching, and updating roles.… roles