### PR TITLE
Implement the method to search with username and email address

### DIFF
--- a/kratos/src/main/java/com/heimdallauth/server/dao/UserProfileMongoDataManagerImpl.java
+++ b/kratos/src/main/java/com/heimdallauth/server/dao/UserProfileMongoDataManagerImpl.java
@@ -76,6 +76,12 @@ public class UserProfileMongoDataManagerImpl implements UserProfileDataManager {
     }
 
     @Override
+    public Optional<UserProfileModel> searchUserProfileWithUsernameOrEmailAddress(String username, String emailAddress) {
+        Query searchQuery = Query.query(Criteria.where("username").regex(username,"i").orOperator(Criteria.where("emailAddress").regex(emailAddress,"i")));
+        return Optional.ofNullable(this.mongoTemplate.findOne(searchQuery, UserProfileDocument.class, USER_PROFILE_COLLECTION_NAME)).map(UserProfileMongoDataManagerImpl::convertToUserProfileModel);
+    }
+
+    @Override
     public Optional<UserProfileModel> updateUserProfile(String profileId, UserProfileModel updatedUserProfileModel) {
         return Optional.empty();
     }

--- a/kratos/src/main/java/com/heimdallauth/server/datamanagers/UserProfileDataManager.java
+++ b/kratos/src/main/java/com/heimdallauth/server/datamanagers/UserProfileDataManager.java
@@ -8,5 +8,6 @@ public interface UserProfileDataManager {
     UserProfileModel createNewUserProfile(String username, String emailAddress, String firstName, String lastName, String phoneNumber);
     Optional<UserProfileModel> getUserProfileById(String profileId);
     Optional<UserProfileModel> searchUserProfile(String searchTerm);
+    Optional<UserProfileModel> searchUserProfileWithUsernameOrEmailAddress(String username, String emailAddress);
     Optional<UserProfileModel> updateUserProfile(String profileId, UserProfileModel updatedUserProfileModel);
 }


### PR DESCRIPTION
This pull request introduces a new method to search user profiles using either a username or an email address. The changes involve updating the data manager interface and its implementation to include this new search functionality.

Key changes include:

* Added `searchUserProfileWithUsernameOrEmailAddress` method to the `UserProfileDataManager` interface.
* Implemented the `searchUserProfileWithUsernameOrEmailAddress` method in `UserProfileMongoDataManagerImpl` to perform the search query using a case-insensitive regex match on either the username or email address.… profiles with username and user email address