### PR TITLE
Fix build issue due to collection name mismatch

### DIFF
--- a/kratos/src/main/java/com/heimdallauth/server/dao/GroupRoleDataManagerMongoImpl.java
+++ b/kratos/src/main/java/com/heimdallauth/server/dao/GroupRoleDataManagerMongoImpl.java
@@ -238,7 +238,7 @@ public class GroupRoleDataManagerMongoImpl implements GroupDataManager, RoleData
         try {
             Aggregation mongoRoleToGroupAggregation = Aggregation.newAggregation(
                     Aggregation.match(Criteria.where("_id").is(roleId)),
-                    Aggregation.lookup(COLLECTION_GROUP_ROLE_MEMBERSHIPS, "_id", "roleId", "groupRoleMemberships")
+                    Aggregation.lookup(GROUP_ROLE_MEMBERSHIP_COLLECTION, "_id", "roleId", "groupRoleMemberships")
 
             );
             Optional<RolesToGroupAggregationModel> roleGroupAggregationResults = Optional.ofNullable(this.mongoTemplate.aggregate(mongoRoleToGroupAggregation, ROLES_COLLECTION, RolesToGroupAggregationModel.class).getUniqueMappedResult());
@@ -252,7 +252,7 @@ public class GroupRoleDataManagerMongoImpl implements GroupDataManager, RoleData
             if (forceDelete) {
                 log.debug("Triggering force delete for role with id: {}, groupIds: {}", roleId, e.ids);
                 Query groupRoleMembershipDeleteQuery = Query.query(Criteria.where("roleId").is(roleId));
-                DeleteResult mongoGroupMembershipDeleteOperationResponse = triggerDelete(groupRoleMembershipDeleteQuery, COLLECTION_GROUP_ROLE_MEMBERSHIPS, GroupRoleMembershipDocument.class);
+                DeleteResult mongoGroupMembershipDeleteOperationResponse = triggerDelete(groupRoleMembershipDeleteQuery, GROUP_ROLE_MEMBERSHIP_COLLECTION, GroupRoleMembershipDocument.class);
                 DeleteResult mongoDeleteOperationResponse = triggerDelete(roleCollectionDeleteQuery, ROLES_COLLECTION, RoleDocument.class);
                 log.info("Force delete operation complete");
             } else {


### PR DESCRIPTION
This pull request includes changes to the `deleteRoleWithGroupMemberships` method in the `GroupRoleDataManagerMongoImpl` class to improve code readability and consistency by updating collection name constants.

Code readability and consistency improvements:

* [`kratos/src/main/java/com/heimdallauth/server/dao/GroupRoleDataManagerMongoImpl.java`](diffhunk://#diff-9857ef85abff67ebbd9fdbc1d04481618deff41d63581c5702bc794b45e94373L241-R241): Updated the collection name from `COLLECTION_GROUP_ROLE_MEMBERSHIPS` to `GROUP_ROLE_MEMBERSHIP_COLLECTION` in the `Aggregation.lookup` method.
* [`kratos/src/main/java/com/heimdallauth/server/dao/GroupRoleDataManagerMongoImpl.java`](diffhunk://#diff-9857ef85abff67ebbd9fdbc1d04481618deff41d63581c5702bc794b45e94373L255-R255): Updated the collection name from `COLLECTION_GROUP_ROLE_MEMBERSHIPS` to `GROUP_ROLE_MEMBERSHIP_COLLECTION` in the `triggerDelete` method call.