### PR TITLE
Updated the ISSUE_TEMPLATE forms for correct type

### DIFF
--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -3,6 +3,7 @@ description: Request an enhancement to an existing feature
 assignees:
   - 'mayanksoni1996'
 title: "[ENHANCEMENT]"
+type: "feature"
 labels: [ "enhancement", "triage" ]
 body:
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,6 +1,7 @@
 name: Task
 description: Any tasks that are not directly adding a new feature, enhancement or fixing a bug
 labels: ["kind/task"]
+type: "task"
 body:
   - type: textarea
     id: description


### PR DESCRIPTION
This pull request includes updates to the issue templates to add a `type` field for better classification of issues.

Enhancements to issue templates:

* [`.github/ISSUE_TEMPLATE/enhancement.yml`](diffhunk://#diff-e4c10e275fca255d4f8c81d9118c0c986bd3a17726db54f154f7d94b56489d12R6): Added a `type` field with the value "feature" to classify enhancement requests.
* [`.github/ISSUE_TEMPLATE/task.yml`](diffhunk://#diff-24ddb99d0699247fe21dffe7eeee5babbaed4567feae20ced0f8dfb06b4b3f7fR4): Added a `type` field with the value "task" to classify general tasks.