### PR TITLE
Kratos: implement redis configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,3 +14,9 @@ services:
       MONGO_INITDB_ROOT_USERNAME: root
       MONGO_INITDB_ROOT_PASSWORD: root
     restart: unless-stopped
+  redis:
+    image: redis:latest
+    container_name: redis
+    ports:
+      - "6379:6379"
+    restart: unless-stopped

--- a/kratos/build.gradle
+++ b/kratos/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-config'
     implementation 'org.springframework.cloud:spring-cloud-starter-consul-discovery'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/kratos/src/main/resources/application-local.yml
+++ b/kratos/src/main/resources/application-local.yml
@@ -5,6 +5,10 @@ spring:
   data:
     mongodb:
       uri: ${MONGO_URI}
+    redis:
+      host: localhost
+      port: 6379
+      database: 0
   cloud:
     config:
       enabled: false


### PR DESCRIPTION
This pull request introduces Redis as a new service in the application. The changes include updates to the `docker-compose.yml`, `build.gradle`, and `application-local.yml` files to integrate Redis.

Integration of Redis:

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R17-R22): Added Redis service configuration with the latest Redis image, container name, and port mapping.
* [`kratos/build.gradle`](diffhunk://#diff-2036b2cbc8fb49e5a120aade6802d8a9481fbed2a1119e4ad733a13b50df7065R38): Added `spring-boot-starter-data-redis` dependency to enable Redis support in the Spring Boot application.
* [`kratos/src/main/resources/application-local.yml`](diffhunk://#diff-1d5a684105db461501bb85c37b09db070c1295a167ec8a6032411d954aa32da2R8-R11): Added Redis configuration settings, including host, port, and database index.