### PR TITLE
Implement Service layer and Controller layer for Configuration Set

### DIFF
--- a/bifrost/build.gradle
+++ b/bifrost/build.gradle
@@ -29,6 +29,7 @@ ext {
 
 dependencies {
     implementation project(":commons")
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.3'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
     implementation 'org.springframework.boot:spring-boot-starter-freemarker'

--- a/bifrost/src/main/java/com/heimdallauth/server/controller/v1/ConfigurationSetManagementController.java
+++ b/bifrost/src/main/java/com/heimdallauth/server/controller/v1/ConfigurationSetManagementController.java
@@ -13,6 +13,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/v1/configuration-set-management")
+@Tag(name = "Configuration Set Management", description = "APIs for managing configuration sets")
 public class ConfigurationSetManagementController {
     private final ConfigurationSetManagementService configurationSetManagementService;
 

--- a/bifrost/src/main/java/com/heimdallauth/server/controller/v1/ConfigurationSetManagementController.java
+++ b/bifrost/src/main/java/com/heimdallauth/server/controller/v1/ConfigurationSetManagementController.java
@@ -1,7 +1,10 @@
 package com.heimdallauth.server.controller.v1;
 
+import com.heimdallauth.server.commons.dto.bifrost.CreateEmailSuppressionListDTO;
 import com.heimdallauth.server.commons.models.bifrost.ConfigurationSet;
+import com.heimdallauth.server.commons.models.bifrost.EmailSuppressionList;
 import com.heimdallauth.server.service.ConfigurationSetManagementService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -34,6 +37,10 @@ public class ConfigurationSetManagementController {
             @PathVariable("configurationSetId") String configurationSetId,
             @PathVariable("suppressionListId") String suppressionListId) {
         return ResponseEntity.ok(configurationSetManagementService.addSuppressionListToConfigurationSet(configurationSetId, suppressionListId));
+    }
+    @PostMapping("/suppression-lists")
+    public ResponseEntity<EmailSuppressionList> createNewEmailSuppressionList(@RequestBody CreateEmailSuppressionListDTO payloadCreateEmailSuppressionList) {
+        return ResponseEntity.ok(configurationSetManagementService.createEmailSuppressionList(payloadCreateEmailSuppressionList));
     }
 
 }

--- a/bifrost/src/main/java/com/heimdallauth/server/controller/v1/ConfigurationSetManagementController.java
+++ b/bifrost/src/main/java/com/heimdallauth/server/controller/v1/ConfigurationSetManagementController.java
@@ -1,0 +1,39 @@
+package com.heimdallauth.server.controller.v1;
+
+import com.heimdallauth.server.commons.models.bifrost.ConfigurationSet;
+import com.heimdallauth.server.service.ConfigurationSetManagementService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/v1/configuration-set-management")
+public class ConfigurationSetManagementController {
+    private final ConfigurationSetManagementService configurationSetManagementService;
+
+    @Autowired
+    public ConfigurationSetManagementController(ConfigurationSetManagementService configurationSetManagementService) {
+        this.configurationSetManagementService = configurationSetManagementService;
+    }
+    @PostMapping
+    public ResponseEntity<ConfigurationSet> createNewConfigurationSet(@RequestBody ConfigurationSet configurationSet) {
+        return ResponseEntity.ok(configurationSetManagementService.createConfigurationSet(configurationSet));
+    }
+    @GetMapping("/{configurationSetId}")
+    public ResponseEntity<ConfigurationSet> getConfigurationSetById(@PathVariable String configurationSetId) {
+        return ResponseEntity.ok(configurationSetManagementService.getConfigurationSetById(configurationSetId));
+    }
+    @GetMapping
+    public ResponseEntity<List<ConfigurationSet>> getAllConfigurationSets(){
+        return ResponseEntity.ok(configurationSetManagementService.getAllConfigurationSets());
+    }
+    @PutMapping("/{configurationSetId}/add-suppression-list/{suppressionListId}")
+    public ResponseEntity<ConfigurationSet> updateAddSuppressionListToConfigurationSet(
+            @PathVariable("configurationSetId") String configurationSetId,
+            @PathVariable("suppressionListId") String suppressionListId) {
+        return ResponseEntity.ok(configurationSetManagementService.addSuppressionListToConfigurationSet(configurationSetId, suppressionListId));
+    }
+
+}

--- a/bifrost/src/main/java/com/heimdallauth/server/datamanagers/impl/mongodb/ConfigurationSetDataManagerMongoImpl.java
+++ b/bifrost/src/main/java/com/heimdallauth/server/datamanagers/impl/mongodb/ConfigurationSetDataManagerMongoImpl.java
@@ -170,6 +170,7 @@ public class ConfigurationSetDataManagerMongoImpl implements ConfigurationSetDat
     public Optional<EmailSuppressionList> getEmailSuppressionListById(String suppressionListId) {
         Query emailSuppressionListQuery = Query.query(Criteria.where("_id").is(suppressionListId));
         return Optional.ofNullable(this.mongoTemplate.findOne(emailSuppressionListQuery, EmailSuppressionListDocument.class, MongoCollectionConstants.EMAIL_SUPPRESSION_LIST_COLLECTION)).map(suppressionDocument -> EmailSuppressionList.builder()
+                .id(suppressionDocument.getId())
                 .suppressionListName(suppressionDocument.getSuppressionListName())
                 .emailSuppressions(suppressionDocument.getEmailSuppressions())
                 .creationTimestamp(suppressionDocument.getCreationTimestamp())

--- a/bifrost/src/main/java/com/heimdallauth/server/service/ConfigurationSetManagementService.java
+++ b/bifrost/src/main/java/com/heimdallauth/server/service/ConfigurationSetManagementService.java
@@ -1,6 +1,8 @@
 package com.heimdallauth.server.service;
 
+import com.heimdallauth.server.commons.dto.bifrost.CreateEmailSuppressionListDTO;
 import com.heimdallauth.server.commons.models.bifrost.ConfigurationSet;
+import com.heimdallauth.server.commons.models.bifrost.EmailSuppressionList;
 import com.heimdallauth.server.datamanagers.ConfigurationSetDataManager;
 import com.heimdallauth.server.datamanagers.EmailSuppressionListDataManager;
 import lombok.extern.slf4j.Slf4j;
@@ -32,5 +34,12 @@ public class ConfigurationSetManagementService {
     }
     public ConfigurationSet addSuppressionListToConfigurationSet(String configurationSetId, String suppressionListId) {
         return configurationSetDataManager.addSuppressionListToConfigurationSet(configurationSetId, suppressionListId).orElse(null);
+    }
+    public EmailSuppressionList createEmailSuppressionList(CreateEmailSuppressionListDTO payloadCreateEmailSuppressionList){
+        return emailSuppressionListDataManager.createEmailSuppressionList(
+                payloadCreateEmailSuppressionList.getSuppressionListName(),
+                payloadCreateEmailSuppressionList.getEmailAddresses(),
+                payloadCreateEmailSuppressionList.isEmailBlocked()
+        );
     }
 }

--- a/bifrost/src/main/java/com/heimdallauth/server/service/ConfigurationSetManagementService.java
+++ b/bifrost/src/main/java/com/heimdallauth/server/service/ConfigurationSetManagementService.java
@@ -1,0 +1,36 @@
+package com.heimdallauth.server.service;
+
+import com.heimdallauth.server.commons.models.bifrost.ConfigurationSet;
+import com.heimdallauth.server.datamanagers.ConfigurationSetDataManager;
+import com.heimdallauth.server.datamanagers.EmailSuppressionListDataManager;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@Slf4j
+public class ConfigurationSetManagementService {
+    private final ConfigurationSetDataManager configurationSetDataManager;
+    private final EmailSuppressionListDataManager emailSuppressionListDataManager;
+
+    @Autowired
+    public ConfigurationSetManagementService(ConfigurationSetDataManager configurationSetDataManager, EmailSuppressionListDataManager emailSuppressionListDataManager) {
+        this.configurationSetDataManager = configurationSetDataManager;
+        this.emailSuppressionListDataManager = emailSuppressionListDataManager;
+    }
+
+    public ConfigurationSet createConfigurationSet(ConfigurationSet configurationSet) {
+        return configurationSetDataManager.createConfigurationSet(configurationSet);
+    }
+    public ConfigurationSet getConfigurationSetById(String configurationSetId) {
+        return configurationSetDataManager.getConfigurationSet(configurationSetId).orElse(null);
+    }
+    public List<ConfigurationSet> getAllConfigurationSets() {
+        return configurationSetDataManager.getAllConfigurationSets();
+    }
+    public ConfigurationSet addSuppressionListToConfigurationSet(String configurationSetId, String suppressionListId) {
+        return configurationSetDataManager.addSuppressionListToConfigurationSet(configurationSetId, suppressionListId).orElse(null);
+    }
+}

--- a/commons/src/main/java/com/heimdallauth/server/commons/dto/bifrost/CreateEmailSuppressionListDTO.java
+++ b/commons/src/main/java/com/heimdallauth/server/commons/dto/bifrost/CreateEmailSuppressionListDTO.java
@@ -1,10 +1,16 @@
 package com.heimdallauth.server.commons.dto.bifrost;
 
 import com.heimdallauth.server.commons.models.bifrost.SuppressionListEmailEntry;
+import lombok.*;
 
 import java.util.List;
-
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
 public class CreateEmailSuppressionListDTO {
     private String suppressionListName;
-    private List<SuppressionListEmailEntry> suppressedEmails;
+    private List<String> emailAddresses;
+    private boolean isEmailBlocked;
 }

--- a/commons/src/main/java/com/heimdallauth/server/commons/models/bifrost/ConfigurationSet.java
+++ b/commons/src/main/java/com/heimdallauth/server/commons/models/bifrost/ConfigurationSet.java
@@ -11,6 +11,7 @@ import java.util.List;
 @Getter
 @Setter
 public class ConfigurationSet {
+    private String id;
     private String configurationSetName;
     private List<EmailSuppressionList> activeEmailSuppressionLists;
     private TrackingOptions trackingOptions;


### PR DESCRIPTION
This pull request introduces several significant changes to the `bifrost` project, including the addition of a new controller, service, and DTOs for managing configuration sets and email suppression lists. Additionally, it includes dependencies updates and enhancements to existing data models.

### New Features and Enhancements:

* **New Controller for Configuration Set Management:**
  - Added `ConfigurationSetManagementController` to handle CRUD operations for configuration sets and email suppression lists.

* **Service Layer for Configuration Set Management:**
  - Introduced `ConfigurationSetManagementService` to manage business logic related to configuration sets and email suppression lists.

* **DTO Enhancements:**
  - Updated `CreateEmailSuppressionListDTO` with new fields and added Lombok annotations for boilerplate code reduction.

### Dependency Updates:

* **Springdoc OpenAPI Integration:**
  - Added `springdoc-openapi-starter-webmvc-ui` dependency to the `build.gradle` file for API documentation.

### Model Enhancements:

* **Configuration Set Model Update:**
  - Added `id` field to the `ConfigurationSet` model.

* **Email Suppression List Model Update:**
  - Included the `id` field in the mapping of `EmailSuppressionList` in `ConfigurationSetDataManagerMongoImpl`.