### PR TITLE
Implement a ConfigurationSet Validation Service

### DIFF
--- a/bifrost/src/main/java/com/heimdallauth/server/datamanagers/impl/mongodb/ConfigurationSetDataManagerMongoImpl.java
+++ b/bifrost/src/main/java/com/heimdallauth/server/datamanagers/impl/mongodb/ConfigurationSetDataManagerMongoImpl.java
@@ -111,7 +111,7 @@ public class ConfigurationSetDataManagerMongoImpl implements ConfigurationSetDat
     @Override
     public Optional<ConfigurationSet> getConfigurationSet(String configurationSetName) {
         Aggregation configurationSetLookupAggregation = Aggregation.newAggregation(
-                Aggregation.match(Criteria.where("configurationSetName").is(configurationSetName)),
+                Aggregation.match(Criteria.where("configurationSetName").regex(configurationSetName, "i")),
                 Aggregation.lookup(MongoCollectionConstants.EMAIL_SUPPRESSION_LIST_COLLECTION, "activeEmailSuppressionListIds", "_id", "activeEmailSuppressionLists"),
                 Aggregation.project()
                         .andExclude("activeEmailSuppressionListIds")

--- a/bifrost/src/main/java/com/heimdallauth/server/service/ConfigurationSetManagementService.java
+++ b/bifrost/src/main/java/com/heimdallauth/server/service/ConfigurationSetManagementService.java
@@ -16,14 +16,17 @@ import java.util.List;
 public class ConfigurationSetManagementService {
     private final ConfigurationSetDataManager configurationSetDataManager;
     private final EmailSuppressionListDataManager emailSuppressionListDataManager;
+    private final ConfigurationSetValidationService configurationSetValidationService;
 
     @Autowired
-    public ConfigurationSetManagementService(ConfigurationSetDataManager configurationSetDataManager, EmailSuppressionListDataManager emailSuppressionListDataManager) {
+    public ConfigurationSetManagementService(ConfigurationSetDataManager configurationSetDataManager, EmailSuppressionListDataManager emailSuppressionListDataManager, ConfigurationSetValidationService configurationSetValidationService) {
         this.configurationSetDataManager = configurationSetDataManager;
         this.emailSuppressionListDataManager = emailSuppressionListDataManager;
+        this.configurationSetValidationService = configurationSetValidationService;
     }
 
     public ConfigurationSet createConfigurationSet(ConfigurationSet configurationSet) {
+        this.configurationSetValidationService.validateConfigurationSet(configurationSet);
         return configurationSetDataManager.createConfigurationSet(configurationSet);
     }
     public ConfigurationSet getConfigurationSetById(String configurationSetId) {

--- a/bifrost/src/main/java/com/heimdallauth/server/service/ConfigurationSetValidationService.java
+++ b/bifrost/src/main/java/com/heimdallauth/server/service/ConfigurationSetValidationService.java
@@ -1,0 +1,59 @@
+package com.heimdallauth.server.service;
+
+import com.heimdallauth.server.commons.models.bifrost.ConfigurationSet;
+import com.heimdallauth.server.commons.models.bifrost.EmailSuppressionList;
+import com.heimdallauth.server.commons.models.bifrost.SuppressionListEmailEntry;
+import com.heimdallauth.server.datamanagers.impl.mongodb.ConfigurationSetDataManagerMongoImpl;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+@Service
+@Slf4j
+public class ConfigurationSetValidationService {
+
+    private final ConfigurationSetDataManagerMongoImpl configurationSetDataManager;
+
+    @Autowired
+    public ConfigurationSetValidationService(ConfigurationSetDataManagerMongoImpl configurationSetDataManager) {
+        this.configurationSetDataManager = configurationSetDataManager;
+    }
+
+    public void validateConfigurationSet(ConfigurationSet configurationSet) {
+        validateUniqueConfigurationSet(configurationSet.getConfigurationSetName());
+        validateCustomRedirectDomain(configurationSet.getTrackingOptions().getCustomTrackingDomain());
+        validateEmailFormat(configurationSet.getActiveEmailSuppressionLists());
+    }
+
+    private void validateUniqueConfigurationSet(String configurationSetName) {
+        Optional<ConfigurationSet> existingConfigurationSet = configurationSetDataManager.getConfigurationSet(configurationSetName);
+        if (existingConfigurationSet.isPresent()) {
+            throw new IllegalArgumentException("Configuration set with name " + configurationSetName + " already exists");
+        }
+    }
+
+    private void validateCustomRedirectDomain(String customRedirectDomain) {
+        if (customRedirectDomain != null && !customRedirectDomain.isEmpty()) {
+            String domainRegex = "^(https?:\\/\\/)?([\\da-z.-]+)\\.([a-z.]{2,6})([\\/\\w .-]*)*\\/?$";
+            if (!Pattern.matches(domainRegex, customRedirectDomain)) {
+                throw new IllegalArgumentException("Invalid custom redirect domain: " + customRedirectDomain);
+            }
+        }
+    }
+
+    private void validateEmailFormat(List<EmailSuppressionList> emailSuppressionLists) {
+        String emailRegex = "^[A-Za-z0-9+_.-]+@(.+)$";
+        Pattern pattern = Pattern.compile(emailRegex);
+        for (EmailSuppressionList emailSuppressionList : emailSuppressionLists) {
+            for (SuppressionListEmailEntry emailEntry : emailSuppressionList.getEmailSuppressions()) {
+                if (!pattern.matcher(emailEntry.getEmailAddress()).matches()) {
+                    throw new IllegalArgumentException("Invalid email format: " + emailEntry.getEmailAddress());
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces validation for `ConfigurationSet` objects and enhances the case-insensitivity of configuration set lookups. The main changes include the addition of a new validation service, modifications to the management service to incorporate validation, and updates to the data manager for case-insensitive searches.

### Validation Enhancements:

* [`bifrost/src/main/java/com/heimdallauth/server/service/ConfigurationSetValidationService.java`](diffhunk://#diff-57503c8b54c0ced6b0c7ca73613e902f77f85277f1198ddd196549e2d39c37bbR1-R59): Added a new `ConfigurationSetValidationService` to perform validations such as uniqueness, custom redirect domain format, and email format.
* [`bifrost/src/main/java/com/heimdallauth/server/service/ConfigurationSetManagementService.java`](diffhunk://#diff-e9a46b1c7e57dc8ea402301c01abc00f8cbe6a21c7cae212556d6ab9829a36efR19-R29): Updated the `ConfigurationSetManagementService` to include the `ConfigurationSetValidationService` and call the validation method during the creation of a configuration set.

### Data Manager Update:

* [`bifrost/src/main/java/com/heimdallauth/server/datamanagers/impl/mongodb/ConfigurationSetDataManagerMongoImpl.java`](diffhunk://#diff-b93355b8ff311ea03a2426aa95767c0f238df4b3e02c557fc16a00d1b9d0b17aL114-R114): Modified the `getConfigurationSet` method to perform case-insensitive searches using regular expressions.