### PR TITLE
Updated the Actions to build release-candidate images

### DIFF
--- a/.github/workflows/docker-matrix-builder.yml
+++ b/.github/workflows/docker-matrix-builder.yml
@@ -2,6 +2,8 @@ name: Docker Matrix Builder
 
 on:
   push:
+    branches:
+      - "release-candidate/**"
     tags:
       - 'v*'
 permissions:


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/docker-matrix-builder.yml` file. The change adds the `release-candidate/**` branch pattern to the list of branches that trigger the workflow on push events.

* [`.github/workflows/docker-matrix-builder.yml`](diffhunk://#diff-1dfa11223c02b6d600866c216154f16450e94a6077ea547d43cdb2a521e981caR5-R6): Added `release-candidate/**` to the branches that trigger the workflow on push events.