### PR TITLE
Implement a TemplateManagement Service

### DIFF
--- a/bifrost/src/main/java/com/heimdallauth/server/datamanagers/TemplateDataManager.java
+++ b/bifrost/src/main/java/com/heimdallauth/server/datamanagers/TemplateDataManager.java
@@ -2,10 +2,13 @@ package com.heimdallauth.server.datamanagers;
 
 import com.heimdallauth.server.commons.models.TemplateModel;
 
+import java.util.List;
+
 public interface TemplateDataManager {
     TemplateModel createTemplate(String templateName, String templateHtmlContent, String templatePlaintextContent, String templateSubject);
     TemplateModel getTemplateById(String id);
     TemplateModel getTemplateByName(String templateName);
     TemplateModel updateTemplate(String id, String templateName, String templateHtmlContent, String templatePlaintextContent, String templateSubject);
     void deleteTemplate(String id);
+    List<TemplateModel> getAllTemplates();
 }

--- a/bifrost/src/main/java/com/heimdallauth/server/datamanagers/impl/mongodb/TemplateDataManagerMongoImpl.java
+++ b/bifrost/src/main/java/com/heimdallauth/server/datamanagers/impl/mongodb/TemplateDataManagerMongoImpl.java
@@ -88,6 +88,13 @@ public class TemplateDataManagerMongoImpl implements TemplateDataManager {
         }
 
     }
+
+    @Override
+    public List<TemplateModel> getAllTemplates() {
+        List<TemplateDocument> templateDocuments = this.mongoTemplate.findAll(TemplateDocument.class, MongoCollectionConstants.TEMPLATE_COLLECTION);
+        return templateDocuments.stream().map(TemplateDocument::toTemplateModel).toList();
+    }
+
     private Optional<TemplateDocument> getTemplateDocumentById(String id){
         Query selectTemplateByIdQuery = Query.query(Criteria.where("id").is(id));
         return Optional.ofNullable(this.mongoTemplate.findOne(selectTemplateByIdQuery, TemplateDocument.class, MongoCollectionConstants.TEMPLATE_COLLECTION));

--- a/bifrost/src/main/java/com/heimdallauth/server/service/TemplateManagementService.java
+++ b/bifrost/src/main/java/com/heimdallauth/server/service/TemplateManagementService.java
@@ -1,0 +1,39 @@
+package com.heimdallauth.server.service;
+
+import com.heimdallauth.server.commons.models.TemplateModel;
+import com.heimdallauth.server.datamanagers.TemplateDataManager;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@Slf4j
+public class TemplateManagementService {
+    private final TemplateDataManager templateDataManager;
+
+    public TemplateManagementService(TemplateDataManager templateDataManager) {
+        this.templateDataManager = templateDataManager;
+    }
+
+    public TemplateModel createNewTemplate(TemplateModel templateModel){
+        return this.createNewTemplate(
+            templateModel.getTemplateName(),
+            templateModel.getTemplateHtmlContent(),
+            templateModel.getTemplatePlaintextContent(),
+            templateModel.getTemplateSubject()
+        );
+    }
+    public TemplateModel createNewTemplate(String templateName, String templateHtmlContent, String templatePlaintextContent, String templateSubject){
+        return this.templateDataManager.createTemplate(templateName, templateHtmlContent, templatePlaintextContent, templateSubject);
+    }
+    public TemplateModel getTemplateById(String id){
+        return this.templateDataManager.getTemplateById(id);
+    }
+    public TemplateModel getTemplateByName(String templateName){
+        return this.templateDataManager.getTemplateByName(templateName);
+    }
+    public List<TemplateModel> getAllTemplates(){
+        return this.templateDataManager.getAllTemplates();
+    }
+}


### PR DESCRIPTION
This pull request introduces a new service class for managing templates and adds a method to retrieve all templates from the database. The most important changes include adding a new `TemplateManagementService` class, updating the `TemplateDataManager` interface, and implementing the new method in the `TemplateDataManagerMongoImpl` class.

### New Service Class:
* [`bifrost/src/main/java/com/heimdallauth/server/service/TemplateManagementService.java`](diffhunk://#diff-efa401b129c7031c644fb4227041a45657b4301f5cad8c57f6e9c32ab4b681a3R1-R39): Added a new `TemplateManagementService` class to handle template-related operations.

### Interface Update:
* [`bifrost/src/main/java/com/heimdallauth/server/datamanagers/TemplateDataManager.java`](diffhunk://#diff-7405aaed3396fced786ac761b67ecfb800e5d5a4aa3e42769efe6eedbfcb8872R5-R13): Updated the `TemplateDataManager` interface to include a `getAllTemplates` method.

### Method Implementation:
* [`bifrost/src/main/java/com/heimdallauth/server/datamanagers/impl/mongodb/TemplateDataManagerMongoImpl.java`](diffhunk://#diff-babb933cc01399045e465daba536db5adec7d2f4c11460dc902dc274645fb737R91-R97): Implemented the `getAllTemplates` method to retrieve all templates from the MongoDB collection.