### PR TITLE
Fix the null audit timestamps on Templates

### DIFF
--- a/bifrost/src/main/java/com/heimdallauth/server/datamanagers/impl/mongodb/TemplateDataManagerMongoImpl.java
+++ b/bifrost/src/main/java/com/heimdallauth/server/datamanagers/impl/mongodb/TemplateDataManagerMongoImpl.java
@@ -11,6 +11,7 @@ import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.stereotype.Repository;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -39,6 +40,8 @@ public class TemplateDataManagerMongoImpl implements TemplateDataManager {
                 .templateHtmlContent(templateHtmlContent)
                 .templatePlaintextContent(templatePlaintextContent)
                 .templateSubject(templateSubject)
+                .createdAt(Instant.now())
+                .lastUpdatedAt(Instant.now())
                 .build();
         List<String> savedIds = this.executeMongoDBSaveOperation(List.of(templateDocument), MongoCollectionConstants.TEMPLATE_COLLECTION);
         if (!savedIds.isEmpty()) {
@@ -70,6 +73,7 @@ public class TemplateDataManagerMongoImpl implements TemplateDataManager {
                     document.setTemplateHtmlContent(templateHtmlContent);
                     document.setTemplatePlaintextContent(templatePlaintextContent);
                     document.setTemplateSubject(templateSubject);
+                    document.setLastUpdatedAt(Instant.now());
                     this.mongoTemplate.save(document, MongoCollectionConstants.TEMPLATE_COLLECTION);
                 },
                 () -> {


### PR DESCRIPTION
This pull request includes changes to the `TemplateDataManagerMongoImpl` class to add timestamp management for template creation and updates. The most important changes are:

Timestamp management:

* [`bifrost/src/main/java/com/heimdallauth/server/datamanagers/impl/mongodb/TemplateDataManagerMongoImpl.java`](diffhunk://#diff-babb933cc01399045e465daba536db5adec7d2f4c11460dc902dc274645fb737R14): Imported `java.time.Instant` to handle timestamps.
* [`bifrost/src/main/java/com/heimdallauth/server/datamanagers/impl/mongodb/TemplateDataManagerMongoImpl.java`](diffhunk://#diff-babb933cc01399045e465daba536db5adec7d2f4c11460dc902dc274645fb737R43-R44): Added `createdAt` and `lastUpdatedAt` fields to the `createTemplate` method to record the creation time.
* [`bifrost/src/main/java/com/heimdallauth/server/datamanagers/impl/mongodb/TemplateDataManagerMongoImpl.java`](diffhunk://#diff-babb933cc01399045e465daba536db5adec7d2f4c11460dc902dc274645fb737R76): Updated the `updateTemplate` method to set the `lastUpdatedAt` field to the current time when a template is updated.