### PR TITLE
Implement a Template Processing Service

### DIFF
--- a/bifrost/build.gradle
+++ b/bifrost/build.gradle
@@ -29,6 +29,7 @@ ext {
 
 dependencies {
     implementation project(":commons")
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.3'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'

--- a/bifrost/src/main/java/com/heimdallauth/server/models/ProcessedEmailBodyModel.java
+++ b/bifrost/src/main/java/com/heimdallauth/server/models/ProcessedEmailBodyModel.java
@@ -1,0 +1,15 @@
+package com.heimdallauth.server.models;
+
+import lombok.*;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class ProcessedEmailBodyModel {
+    private String subject;
+    private String htmlProcessedBody;
+    private String textProcessedBody;
+
+}

--- a/bifrost/src/main/java/com/heimdallauth/server/service/EmailTemplateProcessor.java
+++ b/bifrost/src/main/java/com/heimdallauth/server/service/EmailTemplateProcessor.java
@@ -1,0 +1,42 @@
+package com.heimdallauth.server.service;
+
+import com.heimdallauth.server.commons.models.TemplateModel;
+import com.heimdallauth.server.datamanagers.TemplateDataManager;
+import com.heimdallauth.server.models.ProcessedEmailBodyModel;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+@Service
+@Slf4j
+public class EmailTemplateProcessor {
+    private final TemplateRenderService templateRenderService;
+    private final TemplateDataManager templateDataManager;
+
+    @Autowired
+    public EmailTemplateProcessor(TemplateRenderService templateRenderService, TemplateDataManager templateDataManager) {
+        this.templateRenderService = templateRenderService;
+        this.templateDataManager = templateDataManager;
+    }
+    public ProcessedEmailBodyModel processEmailTemplateByTemplateName(String templateName, Map<String, Object> variablesValueMap){
+        TemplateModel template = templateDataManager.getTemplateByName(templateName);
+        return processEmailTemplate(template, variablesValueMap);
+    }
+    public ProcessedEmailBodyModel processEmailTemplateById(String templateId, Map<String, Object> variablesValueMap){
+        TemplateModel template = templateDataManager.getTemplateById(templateId);
+        return processEmailTemplate(template, variablesValueMap);
+    }
+
+    private ProcessedEmailBodyModel processEmailTemplate(TemplateModel template, Map<String, Object> variablesValueMap){
+        String processedSubjectString = templateRenderService.renderTemplatedString(template.getTemplateSubject(), variablesValueMap);
+        String processedHtmlBodyString = templateRenderService.renderTemplatedString(template.getTemplateHtmlContent(), variablesValueMap);
+        String processedTextBodyString = templateRenderService.renderTemplatedString(template.getTemplatePlaintextContent(), variablesValueMap);
+        return ProcessedEmailBodyModel.builder()
+                .subject(processedSubjectString)
+                .htmlProcessedBody(processedHtmlBodyString)
+                .textProcessedBody(processedTextBodyString)
+                .build();
+    }
+}

--- a/bifrost/src/main/java/com/heimdallauth/server/service/TemplateRenderService.java
+++ b/bifrost/src/main/java/com/heimdallauth/server/service/TemplateRenderService.java
@@ -1,0 +1,24 @@
+package com.heimdallauth.server.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+
+import java.util.Map;
+
+@Service
+@Slf4j
+public class TemplateRenderService {
+    private final SpringTemplateEngine springTemplateEngine;
+
+    public TemplateRenderService(SpringTemplateEngine springTemplateEngine) {
+        this.springTemplateEngine = springTemplateEngine;
+    }
+    public String renderTemplatedString(String templatedString, Map<String, Object> variableValueMap){
+        log.debug("Rendering templated string: {}", templatedString);
+        Context thymeleafContext = new Context();
+        thymeleafContext.setVariables(variableValueMap);
+        return springTemplateEngine.process(templatedString, thymeleafContext);
+    }
+}


### PR DESCRIPTION
This pull request introduces several new features and dependencies to the `bifrost` project, focusing on email template processing and rendering. The key changes include adding a new dependency for Thymeleaf, creating models and services for processing email templates, and rendering templates using Thymeleaf.

### New Dependencies:
* Added `spring-boot-starter-thymeleaf` to the `bifrost/build.gradle` file to facilitate template rendering.

### New Models:
* Created a `ProcessedEmailBodyModel` class to represent the processed email content, including subject, HTML, and text bodies.

### New Services:
* Added `EmailTemplateProcessor` service to handle the processing of email templates by name or ID, utilizing the `TemplateRenderService` for rendering.
* Introduced `TemplateRenderService` to render templated strings using Thymeleaf, including setting up the Spring Template Engine and processing templates with provided variables.