### PR TITLE
[Send Email] Create Models and DTO for API payload 

### DIFF
--- a/commons/src/main/java/com/heimdallauth/server/commons/dto/bifrost/SendEmailPayload.java
+++ b/commons/src/main/java/com/heimdallauth/server/commons/dto/bifrost/SendEmailPayload.java
@@ -1,0 +1,18 @@
+package com.heimdallauth.server.commons.dto.bifrost;
+
+import com.heimdallauth.server.commons.models.bifrost.ConfigurationSet;
+import com.heimdallauth.server.commons.models.bifrost.RecipientModel;
+import com.heimdallauth.server.commons.models.bifrost.TemplateModel;
+import lombok.*;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class SendEmailPayload {
+    private RecipientModel recipients;
+    private TemplateModel template;
+    private ConfigurationSet activeConfigurationSet;
+    private Object data;
+}

--- a/commons/src/main/java/com/heimdallauth/server/commons/dto/bifrost/SendEmailPayload.java
+++ b/commons/src/main/java/com/heimdallauth/server/commons/dto/bifrost/SendEmailPayload.java
@@ -15,4 +15,5 @@ public class SendEmailPayload {
     private TemplateModel template;
     private ConfigurationSet activeConfigurationSet;
     private Object data;
+    private String replyToEmailAddress;
 }

--- a/commons/src/main/java/com/heimdallauth/server/commons/models/bifrost/RecipientModel.java
+++ b/commons/src/main/java/com/heimdallauth/server/commons/models/bifrost/RecipientModel.java
@@ -1,0 +1,16 @@
+package com.heimdallauth.server.commons.models.bifrost;
+
+import lombok.*;
+
+import java.util.List;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class RecipientModel {
+    private List<String> to;
+    private List<String> cc;
+    private List<String> bcc;
+}


### PR DESCRIPTION
This pull request introduces new data transfer objects (DTOs) for handling email payloads and recipient information in the Bifrost module. The most important changes include the addition of the `SendEmailPayload` and `RecipientModel` classes, which will be used to structure email-related data.

### New DTOs for Email Handling:

* [`commons/src/main/java/com/heimdallauth/server/commons/dto/bifrost/SendEmailPayload.java`](diffhunk://#diff-db0768243b1d3bf697a62c0f24ed248d81208445ef3472fa9be0db982ee7dc85R1-R19): Added the `SendEmailPayload` class to encapsulate the details of an email payload, including recipients, template, configuration set, data, and reply-to email address.

* [`commons/src/main/java/com/heimdallauth/server/commons/models/bifrost/RecipientModel.java`](diffhunk://#diff-011a830aebe8765f696ffb05fd46aaef55de6c3f3f56995216249e21f620f133R1-R16): Added the `RecipientModel` class to represent the recipient information, including lists of "to", "cc", and "bcc" email addresses.