### PR TITLE
Service layer for handling SendEmail API operations

### DIFF
--- a/bifrost/src/main/java/com/heimdallauth/server/datamanagers/impl/mongodb/TemplateDataManagerMongoImpl.java
+++ b/bifrost/src/main/java/com/heimdallauth/server/datamanagers/impl/mongodb/TemplateDataManagerMongoImpl.java
@@ -55,7 +55,7 @@ public class TemplateDataManagerMongoImpl implements TemplateDataManager {
     @Override
     public TemplateModel getTemplateById(String id) {
         Optional<TemplateDocument> templateDocument = this.getTemplateDocumentById(id);
-        return templateDocument.map(TemplateDocument::toTemplateModel).orElseThrow();
+        return templateDocument.map(TemplateDocument::toTemplateModel).orElseThrow(() -> new TemplateDoesNotExists("Template with id " + id + " does not exist"));
     }
 
     @Override

--- a/bifrost/src/main/java/com/heimdallauth/server/service/EmailTemplateProcessor.java
+++ b/bifrost/src/main/java/com/heimdallauth/server/service/EmailTemplateProcessor.java
@@ -20,16 +20,9 @@ public class EmailTemplateProcessor {
         this.templateRenderService = templateRenderService;
         this.templateDataManager = templateDataManager;
     }
-    public ProcessedEmailBodyModel processEmailTemplateByTemplateName(String templateName, Map<String, Object> variablesValueMap){
-        TemplateModel template = templateDataManager.getTemplateByName(templateName);
-        return processEmailTemplate(template, variablesValueMap);
-    }
-    public ProcessedEmailBodyModel processEmailTemplateById(String templateId, Map<String, Object> variablesValueMap){
-        TemplateModel template = templateDataManager.getTemplateById(templateId);
-        return processEmailTemplate(template, variablesValueMap);
-    }
 
-    private ProcessedEmailBodyModel processEmailTemplate(TemplateModel template, Map<String, Object> variablesValueMap){
+
+    protected ProcessedEmailBodyModel processEmailTemplate(TemplateModel template, Map<String, Object> variablesValueMap){
         String processedSubjectString = templateRenderService.renderTemplatedString(template.getTemplateSubject(), variablesValueMap);
         String processedHtmlBodyString = templateRenderService.renderTemplatedString(template.getTemplateHtmlContent(), variablesValueMap);
         String processedTextBodyString = templateRenderService.renderTemplatedString(template.getTemplatePlaintextContent(), variablesValueMap);

--- a/bifrost/src/main/java/com/heimdallauth/server/service/SendEmailProcessor.java
+++ b/bifrost/src/main/java/com/heimdallauth/server/service/SendEmailProcessor.java
@@ -1,0 +1,94 @@
+package com.heimdallauth.server.service;
+
+import com.heimdallauth.server.commons.dto.bifrost.SendEmailPayload;
+import com.heimdallauth.server.commons.models.bifrost.TemplateModel;
+import com.heimdallauth.server.datamanagers.TemplateDataManager;
+import com.heimdallauth.server.exceptions.TemplateDoesNotExists;
+import com.heimdallauth.server.models.ProcessedEmailBodyModel;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.el.util.ReflectionUtil;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.util.ReflectionUtils;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
+
+@Service
+@Slf4j
+public class SendEmailProcessor {
+    private final TemplateDataManager templateDM;
+    private final EmailTemplateProcessor emailTemplateProcessor;
+
+    @Autowired
+    public SendEmailProcessor(TemplateDataManager templateDM, EmailTemplateProcessor emailTemplateProcessor) {
+        this.templateDM = templateDM;
+        this.emailTemplateProcessor = emailTemplateProcessor;
+    }
+
+    public void processSendEmailApiPayload(SendEmailPayload sendEmail){
+        log.debug("Processing send email payload: {}", sendEmail);
+        if(sendEmail.getTemplate() != null){
+            TemplateModel template = sendEmail.getTemplate();
+            if(template.getId() !=null || template.getTemplateName() != null) {
+                this.processByFetchingFromDataStore(template.getId() ==null ? template.getTemplateName() : template.getId(), sendEmail);
+            }else if(template.getTemplateHtmlContent() != null || template.getTemplatePlaintextContent() != null || template.getTemplateSubject() != null){
+                assert template.getTemplateSubject() != null;
+                assert template.getTemplatePlaintextContent() != null;
+                assert template.getTemplateHtmlContent() != null;
+                this.processInlineTemplate(template, sendEmail.getData());
+            }
+        }
+    }
+    private void processByFetchingFromDataStore(String templateId, SendEmailPayload sendEmail){
+        TemplateModel template;
+        log.info("Processing send email payload by fetching from data store: {}", sendEmail);
+        try{
+            String validatedUUID =  UUID.fromString(templateId).toString();
+            template = this.templateDM.getTemplateById(validatedUUID);
+        }catch (IllegalArgumentException e){
+            log.debug("Template ID is not a valid UUID: {}", templateId);
+            template = this.templateDM.getTemplateByName(templateId);
+        }catch (TemplateDoesNotExists e){
+            log.error("Template does not exists: {}", templateId);
+            return;
+        }
+        this.processInitiateEmailTemplating(template, sendEmail.getData());
+    }
+    private void processInlineTemplate(TemplateModel inlineTemplateModel, Object data){
+        log.info("Processing inline template: {}", inlineTemplateModel);
+        this.processInitiateEmailTemplating(inlineTemplateModel, data);
+    }
+
+    private void processInitiateEmailTemplating(TemplateModel template, Object data){
+        log.info("Processing initiate email templating: {}", template);
+        ProcessedEmailBodyModel processedEmailBody = this.emailTemplateProcessor.processEmailTemplate(template, convertDataToMap(data));
+    }
+
+    private void executeEmailSend(ProcessedEmailBodyModel processedEmailBody, SendEmailPayload sendEmail){
+        log.info("Executing email send: {}", sendEmail);
+        //TODO implement the service call to the JavaMailSender
+    }
+
+    private static Map<String, Object> convertDataToMap(Object data){
+        Map<String, Object> resultMap = new HashMap<>();
+        if(data == null){
+            return Collections.emptyMap();
+        }
+        Field[] declaredFields = data.getClass().getDeclaredFields();
+        for (Field field: declaredFields){
+            ReflectionUtils.makeAccessible(field);
+            try{
+                resultMap.put(field.getName(), field.get(data));
+            } catch (IllegalAccessException e) {
+                log.error("Failed to convert data to map : {}, errorMessage: {}", field,e.getMessage());
+            }
+        }
+        return resultMap;
+    }
+}


### PR DESCRIPTION
This pull request introduces changes to improve error handling, refactor email template processing methods, and add a new class for processing email sending. The most important changes include modifying the exception handling in `getTemplateById`, refactoring methods in `EmailTemplateProcessor`, and adding the `SendEmailProcessor` class.

Error handling improvements:

* [`bifrost/src/main/java/com/heimdallauth/server/datamanagers/impl/mongodb/TemplateDataManagerMongoImpl.java`](diffhunk://#diff-babb933cc01399045e465daba536db5adec7d2f4c11460dc902dc274645fb737L58-R58): Enhanced the `getTemplateById` method to throw a `TemplateDoesNotExists` exception with a descriptive message when a template is not found.

Refactoring email template processing:

* [`bifrost/src/main/java/com/heimdallauth/server/service/EmailTemplateProcessor.java`](diffhunk://#diff-d587a091a6a120621e29c42351227400ef3a66b4c2a9bee98d91d9e235c2d418L23-R25): Removed redundant methods `processEmailTemplateByTemplateName` and `processEmailTemplateById`, and made `processEmailTemplate` method protected.

New class for email sending:

* [`bifrost/src/main/java/com/heimdallauth/server/service/SendEmailProcessor.java`](diffhunk://#diff-636db5d6a315bf88d5c86bb233df8a6c81647424fd3f7961741b20fc76a05d9fR1-R94): Added a new `SendEmailProcessor` class to handle email sending, including methods to process payloads, fetch templates from the data store, and convert data to a map.