### PR TITLE
Implement API endpoints for sending emails

### DIFF
--- a/bifrost/src/main/java/com/heimdallauth/server/controller/v1/ExecuteSendEmail.java
+++ b/bifrost/src/main/java/com/heimdallauth/server/controller/v1/ExecuteSendEmail.java
@@ -1,0 +1,28 @@
+package com.heimdallauth.server.controller.v1;
+
+import com.heimdallauth.server.commons.dto.bifrost.SendEmailPayload;
+import com.heimdallauth.server.service.SendEmailProcessor;
+import jakarta.mail.MessagingException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/emails")
+public class ExecuteSendEmail {
+    private final SendEmailProcessor sendEmailProcessor;
+
+    @Autowired
+    public ExecuteSendEmail(SendEmailProcessor sendEmailProcessor) {
+        this.sendEmailProcessor = sendEmailProcessor;
+    }
+
+    @PostMapping("/send")
+    public ResponseEntity<Void> sendEmail(@RequestBody SendEmailPayload sendEmailPayload) throws MessagingException {
+        this.sendEmailProcessor.processSendEmailApiPayload(sendEmailPayload);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,6 @@ services:
     image: rnwood/smtp4dev:latest
     container_name: smtp4dev
     ports:
-      - "5000:80"
+      - "3000:80"
       - "2525:25"
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,3 +20,10 @@ services:
     ports:
       - "6379:6379"
     restart: unless-stopped
+  smtp4dev:
+    image: rnwood/smtp4dev:latest
+    container_name: smtp4dev
+    ports:
+      - "5000:80"
+      - "2525:25"
+    restart: unless-stopped


### PR DESCRIPTION
This pull request introduces a new email sending feature and updates the Docker Compose configuration to include an SMTP server for development purposes. The most important changes are:

### New Email Sending Feature:

* [`bifrost/src/main/java/com/heimdallauth/server/controller/v1/ExecuteSendEmail.java`](diffhunk://#diff-afc9413e9936ff0331ee78c4d909a4565184411ea8a8504ba1db902da6afd4e7R1-R28): Added a new controller class `ExecuteSendEmail` to handle email sending requests. This class includes a POST endpoint `/v1/emails/send` that processes email payloads using the `SendEmailProcessor` service.

### Docker Compose Update:

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R23-R29): Added a new service `smtp4dev` to the Docker Compose configuration. This service runs the `rnwood/smtp4dev` image, which provides an SMTP server for development and testing purposes. It exposes ports 3000 and 2525.