### PR TITLE
Develop Utility helper class for JWK generation

### DIFF
--- a/hydra/src/main/java/com/heimdallauth/server/utils/CryptoUtils.java
+++ b/hydra/src/main/java/com/heimdallauth/server/utils/CryptoUtils.java
@@ -1,0 +1,68 @@
+package com.heimdallauth.server.utils;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.jwk.*;
+import lombok.extern.slf4j.Slf4j;
+
+import java.security.InvalidAlgorithmParameterException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.interfaces.ECPublicKey;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.ECGenParameterSpec;
+
+@Slf4j
+public class CryptoUtils {
+    private static final String RSA_ALGORITHM = "RSA";
+    private static final String EC_ALGORITHM = "EC";
+
+
+    public static KeyPair generateRSAKeyPair(int keySize){
+        try{
+            KeyPairGenerator kpGen = KeyPairGenerator.getInstance(RSA_ALGORITHM);
+            kpGen.initialize(keySize);
+            return kpGen.generateKeyPair();
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    public static KeyPair generateECKeyPair(String curveName){
+        try{
+            KeyPairGenerator kpGen = KeyPairGenerator.getInstance(EC_ALGORITHM);
+            ECGenParameterSpec ecSpec = new ECGenParameterSpec(curveName);
+            kpGen.initialize(ecSpec);
+            return kpGen.generateKeyPair();
+        } catch (NoSuchAlgorithmException | InvalidAlgorithmParameterException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static JWK convertToJWKPublic(KeyPair kp){
+        JWK jwkWithPrivate = convertToJWKPrivate(kp);
+        return jwkWithPrivate.toPublicJWK();
+    }
+
+    private static JWK convertToJWKPrivate(KeyPair keyPair){
+        try{
+            if(keyPair.getPrivate().getAlgorithm().equals(RSA_ALGORITHM)){
+                return new RSAKey.Builder((RSAPublicKey) keyPair.getPublic())
+                        .keyUse(KeyUse.SIGNATURE)
+                        .privateKey((RSAPrivateKey) keyPair.getPrivate())
+                        .keyIDFromThumbprint()
+                        .build();
+            }
+            else if(keyPair.getPrivate().getAlgorithm().equals(EC_ALGORITHM)) {
+                return new ECKey.Builder(Curve.forECParameterSpec(((ECPublicKey) keyPair.getPublic()).getParams()), (ECPublicKey) keyPair.getPublic())
+                        .privateKey(keyPair.getPrivate())
+                        .keyIDFromThumbprint()
+                        .build();
+            }else{
+                throw new IllegalArgumentException("Unsupported key type");
+            }
+        } catch (JOSEException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/hydra/src/test/java/com/heimdallauth/server/utils/CryptoUtilsTest.java
+++ b/hydra/src/test/java/com/heimdallauth/server/utils/CryptoUtilsTest.java
@@ -1,0 +1,39 @@
+package com.heimdallauth.server.utils;
+
+import com.nimbusds.jose.jwk.JWK;
+import org.junit.jupiter.api.Test;
+
+import java.security.KeyPair;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CryptoUtilsTest {
+
+    @Test
+    void generateRSAKeyPair() {
+        KeyPair kp = CryptoUtils.generateRSAKeyPair(2048);
+        assertNotNull(kp);
+        assertEquals("RSA", kp.getPrivate().getAlgorithm());
+    }
+
+    @Test
+    void generateECKeyPair() {
+    }
+
+    @Test
+    void convertRSAKeyPairToJWK() {
+        KeyPair kp = CryptoUtils.generateRSAKeyPair(2048);
+        assertNotNull(kp);
+        assertEquals("RSA", kp.getPrivate().getAlgorithm());
+        JWK jwk = CryptoUtils.convertToJWKPublic(kp);
+        assertNotNull(jwk);
+    }
+    @Test
+    void convertRSAKeyPairToJWK4096() {
+        KeyPair kp = CryptoUtils.generateRSAKeyPair(4096);
+        assertNotNull(kp);
+        assertEquals("RSA", kp.getPrivate().getAlgorithm());
+        JWK jwk = CryptoUtils.convertToJWKPublic(kp);
+        assertNotNull(jwk);
+    }
+}


### PR DESCRIPTION
This pull request introduces a new utility class for cryptographic operations and corresponding tests. The most important changes include the addition of methods for generating RSA and EC key pairs, converting key pairs to JWK, and creating unit tests for these methods.

### Crypto utility methods:

* [`hydra/src/main/java/com/heimdallauth/server/utils/CryptoUtils.java`](diffhunk://#diff-b5f14796e2912ee4aa806f69174eab1201b43ae1ddf788ca6b34a9235e014d44R1-R68): Added methods for generating RSA and EC key pairs, and converting key pairs to JWK format.

### Unit tests:

* [`hydra/src/test/java/com/heimdallauth/server/utils/CryptoUtilsTest.java`](diffhunk://#diff-c12dd2fe4a9eb464a5ca6d4c8f3836f4eb3cd90778725f0b357d9220fc7cc604R1-R39): Added unit tests for RSA key pair generation and conversion to JWK.…y pair securely