### PR TITLE
Implement Cacheing for frequently used data

### DIFF
--- a/hydra/build.gradle
+++ b/hydra/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
 //    implementation 'com.auth0:java-jwt:3.3.0'
     implementation 'com.nimbusds:nimbus-jose-jwt:10.0.1'
+    implementation 'com.github.ben-manes.caffeine:caffeine:3.2.0'
 //    implementation 'org.springframework.boot:spring-boot-starter-oauth2-authorization-server'
     implementation 'org.springframework.cloud:spring-cloud-starter-consul-discovery'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'

--- a/hydra/src/main/java/com/heimdallauth/server/config/CacheConfig.java
+++ b/hydra/src/main/java/com/heimdallauth/server/config/CacheConfig.java
@@ -1,0 +1,24 @@
+package com.heimdallauth.server.config;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.nimbusds.jose.jwk.JWK;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+    @Bean
+    public Caffeine<Object, Object> caffeineCacheConfig(){
+        return Caffeine.newBuilder().expireAfterWrite(Duration.of(30, ChronoUnit.MINUTES)).maximumSize(1000);
+    }
+    @Bean
+    public RedisCacheConfiguration redisCacheConfiguration(){
+        return RedisCacheConfiguration.defaultCacheConfig().entryTtl(Duration.of(15, ChronoUnit.HOURS)).disableCachingNullValues();
+    }
+}

--- a/hydra/src/main/java/com/heimdallauth/server/config/CacheManagerConfiguration.java
+++ b/hydra/src/main/java/com/heimdallauth/server/config/CacheManagerConfiguration.java
@@ -1,0 +1,35 @@
+package com.heimdallauth.server.config;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.cache.support.CompositeCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+
+@Configuration
+public class CacheManagerConfiguration {
+    @Bean
+    public CacheManager caffeineCacheManager(Caffeine<Object, Object> caffeine) {
+        CaffeineCacheManager cacheManager = new CaffeineCacheManager("publicJsonWebKeysCache","authorizationServerCache");
+        cacheManager.setCaffeine(caffeine);
+        return cacheManager;
+    }
+
+    @Bean
+    public CacheManager redisCacheManager(RedisConnectionFactory redisConnectionFactory) {
+        return RedisCacheManager.builder(redisConnectionFactory).build();
+    }
+
+    @Primary
+    @Bean
+    public CacheManager compositeCacheManager(
+            CacheManager caffeineCacheManager,
+            CacheManager redisCacheManager
+    ) {
+        return new CompositeCacheManager(caffeineCacheManager, redisCacheManager);
+    }
+}

--- a/hydra/src/main/java/com/heimdallauth/server/datamanagers/impl/mongodb/AuthorizationServerDataManagerMongoImpl.java
+++ b/hydra/src/main/java/com/heimdallauth/server/datamanagers/impl/mongodb/AuthorizationServerDataManagerMongoImpl.java
@@ -8,6 +8,8 @@ import com.heimdallauth.server.utils.RandomIdGeneratorUtil;
 import com.mongodb.client.result.DeleteResult;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
@@ -55,7 +57,9 @@ public class AuthorizationServerDataManagerMongoImpl implements AuthorizationSer
     }
 
     @Override
+    @Cacheable(value = "authorizationServerCache", key="#serverId", unless = "#result == null")
     public AuthorizationServerModel getAuthorizationServerById(String serverId) {
+        log.info("Triggering DB call to get Authorization Server with id: {}", serverId);
         AuthorizationServerDocument authorizationServerDocument = getAuthorizationServerDocumentById(serverId);
         return authorizationServerDocument.toAuthorizationServerModel();
     }
@@ -66,6 +70,7 @@ public class AuthorizationServerDataManagerMongoImpl implements AuthorizationSer
     }
 
     @Override
+    @Cacheable(value = "authorizationServerCache", key="'allservers'")
     public List<AuthorizationServerModel> getAuthorizationServers() {
         List<AuthorizationServerDocument> authorizationServerDocuments = mongoTemplate.findAll(AuthorizationServerDocument.class, AUTHORIZATION_SERVERS_COLLECTION_NAME);
         return authorizationServerDocuments.stream().map(AuthorizationServerDocument::toAuthorizationServerModel).toList();
@@ -89,6 +94,7 @@ public class AuthorizationServerDataManagerMongoImpl implements AuthorizationSer
     Possible race condition (when authorized server ids are cascaded) not required to be handled now but will need to be handled in Aggregation Pipelines. - not handled
      */
     @Override
+    @Cacheable(value ="authorizationServerCache", key = "#serverIds", unless = "#result == null")
     public List<AuthorizationServerModel> getAuthorizationServersByIds(List<String> serverIds) {
         Set<String> serverIdsSet = new HashSet<>(serverIds); //remove duplicated ids.
         Query authorizationServersByIds = Query.query(Criteria.where("id").in(serverIdsSet));

--- a/hydra/src/main/java/com/heimdallauth/server/datamanagers/impl/mongodb/KeyDataManagerMongoImpl.java
+++ b/hydra/src/main/java/com/heimdallauth/server/datamanagers/impl/mongodb/KeyDataManagerMongoImpl.java
@@ -7,6 +7,7 @@ import com.heimdallauth.server.services.VaultEncryptionService;
 import com.heimdallauth.server.utils.CryptoUtils;
 import com.nimbusds.jose.jwk.JWK;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
@@ -49,6 +50,7 @@ public class KeyDataManagerMongoImpl implements KeyDataManager {
     }
 
     @Override
+    @Cacheable(value = "publicJsonWebKeysCache", key="#keyId", unless = "#result == null")
     public JWK getPrivateKey(String keyId) {
         Query query = Query.query(Criteria.where("id").is(keyId));
         Optional<PrivateKeyDocument> privateKeyDocument = Optional.ofNullable(this.mongoTemplate.findOne(query, PrivateKeyDocument.class, PRIVATE_KEY_COLLECTION));


### PR DESCRIPTION
This pull request introduces caching mechanisms using Caffeine and Redis to improve the performance of the `hydra` project. The changes include adding new dependencies, configuring cache settings, and applying caching annotations to relevant methods.

### Caching Improvements:

* **Dependencies**:
  * Added `com.github.ben-manes.caffeine:caffeine:3.2.0` to the `build.gradle` file.

* **Configuration**:
  * Created `CacheConfig.java` to configure Caffeine and Redis cache settings.
  * Created `CacheManagerConfiguration.java` to set up Caffeine and Redis cache managers and a composite cache manager.

* **Cache Annotations**:
  * Applied `@Cacheable` and `@CacheEvict` annotations in `AuthorizationServerDataManagerMongoImpl.java` to cache authorization server data. [[1]](diffhunk://#diff-883b18f381e7f6505322eb83f1bc8b0a601a321074ac376cc860b1db25b5f5c4R11-R12) [[2]](diffhunk://#diff-883b18f381e7f6505322eb83f1bc8b0a601a321074ac376cc860b1db25b5f5c4R60-R62) [[3]](diffhunk://#diff-883b18f381e7f6505322eb83f1bc8b0a601a321074ac376cc860b1db25b5f5c4R73) [[4]](diffhunk://#diff-883b18f381e7f6505322eb83f1bc8b0a601a321074ac376cc860b1db25b5f5c4R97)
  * Applied `@Cacheable` annotation in `KeyDataManagerMongoImpl.java` to cache cryptographic key data. [[1]](diffhunk://#diff-b0046adcd75edd448e3a4752641052d6ef85ae4ed2937c18c1c325c8e45ba514R10) [[2]](diffhunk://#diff-b0046adcd75edd448e3a4752641052d6ef85ae4ed2937c18c1c325c8e45ba514R53)