### PR TITLE
Implement Caching for Authorization Server and Public JWT keys

### DIFF
--- a/hydra/src/main/java/com/heimdallauth/server/controllers/v1/JWKControllers.java
+++ b/hydra/src/main/java/com/heimdallauth/server/controllers/v1/JWKControllers.java
@@ -1,7 +1,6 @@
 package com.heimdallauth.server.controllers.v1;
 
 import com.heimdallauth.server.services.KeyManagementService;
-import com.nimbusds.jose.jwk.JWK;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;

--- a/hydra/src/main/java/com/heimdallauth/server/datamanagers/AuthorizationServerDataManager.java
+++ b/hydra/src/main/java/com/heimdallauth/server/datamanagers/AuthorizationServerDataManager.java
@@ -12,6 +12,6 @@ public interface AuthorizationServerDataManager {
     List<AuthorizationServerModel> getInactiveAuthorizationServers();
     List<AuthorizationServerModel> getAuthorizationServersByIds(List<String> serverIds);
     AuthorizationServerModel updateSigningKeyId(String authorizationServerId, String signingKeyId);
-    AuthorizationServerModel updateAuthorizationServer(String serverId, String serverName, String serverDescription, boolean isActive, List<String> authorizedServerIds);
+    void updateAuthorizationServer(String serverId, String serverName, String serverDescription, boolean isActive, List<String> authorizedServerIds);
     void deleteAuthorizationServer(String serverId);
 }

--- a/hydra/src/main/java/com/heimdallauth/server/datamanagers/impl/mongodb/AuthorizationServerDataManagerMongoImpl.java
+++ b/hydra/src/main/java/com/heimdallauth/server/datamanagers/impl/mongodb/AuthorizationServerDataManagerMongoImpl.java
@@ -8,7 +8,6 @@ import com.heimdallauth.server.utils.RandomIdGeneratorUtil;
 import com.mongodb.client.result.DeleteResult;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
@@ -53,7 +52,7 @@ public class AuthorizationServerDataManagerMongoImpl implements AuthorizationSer
                 .signingKeyId(signingKeyId)
                 .build();
         String savedServerId = executeDbSaveOperation(List.of(authorizationServerDocument), AUTHORIZATION_SERVERS_COLLECTION_NAME).getFirst();
-        return getAuthorizationServerById(savedServerId);
+        return Optional.ofNullable(this.mongoTemplate.findById(savedServerId, AuthorizationServerDocument.class, AUTHORIZATION_SERVERS_COLLECTION_NAME)).map(AuthorizationServerDocument::toAuthorizationServerModel).orElseThrow(() -> new RuntimeException("Authorization Server not found"));
     }
 
     @Override

--- a/hydra/src/main/java/com/heimdallauth/server/datamanagers/impl/mongodb/AuthorizationServerDataManagerMongoImpl.java
+++ b/hydra/src/main/java/com/heimdallauth/server/datamanagers/impl/mongodb/AuthorizationServerDataManagerMongoImpl.java
@@ -8,6 +8,7 @@ import com.heimdallauth.server.utils.RandomIdGeneratorUtil;
 import com.mongodb.client.result.DeleteResult;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
@@ -40,6 +41,7 @@ public class AuthorizationServerDataManagerMongoImpl implements AuthorizationSer
         return this.mongoBulkOperationsDAOService.executeMongoDBSaveOperation(documentsToSave, collectionName);
     }
     @Override
+    @CacheEvict(value ="authorizationServerCache", key = "'allservers'") //Clear the all servers cache.
     public AuthorizationServerModel createAuthorizationServer(String serverName, String serverDescription, boolean isActive, List<String> authorizedServerIds, String signingKeyId) {
         String serverId = RandomIdGeneratorUtil.generateRandomizedAlphaNumericId();
         AuthorizationServerDocument authorizationServerDocument = AuthorizationServerDocument.builder()
@@ -62,6 +64,7 @@ public class AuthorizationServerDataManagerMongoImpl implements AuthorizationSer
         AuthorizationServerDocument authorizationServerDocument = getAuthorizationServerDocumentById(serverId);
         return authorizationServerDocument.toAuthorizationServerModel();
     }
+
     private AuthorizationServerDocument getAuthorizationServerDocumentById(String serverId){
         Query query = new Query();
         query.addCriteria(Criteria.where("id").is(serverId));
@@ -102,17 +105,27 @@ public class AuthorizationServerDataManagerMongoImpl implements AuthorizationSer
     }
 
     @Override
+    @CacheEvict(value = "authorizationServerCache", key = "#authorizationServerId", beforeInvocation = true)
     public AuthorizationServerModel updateSigningKeyId(String authorizationServerId, String signingKeyId) {
+        AuthorizationServerDocument document = getAuthorizationServerDocumentById(authorizationServerId);
+        String oldSigningKeyId = document.getSigningKeyId();
         Update updateSpec= new Update();
         updateSpec.set("signingKeyId", signingKeyId);
+        updateSpec.set("legacySigningKeyId", oldSigningKeyId);
         Query authorizationServerById = Query.query(Criteria.where("id").is(authorizationServerId));
         mongoTemplate.updateFirst(authorizationServerById, updateSpec, AuthorizationServerDocument.class, AUTHORIZATION_SERVERS_COLLECTION_NAME);
-        return this.getAuthorizationServerById(authorizationServerId);
+        AuthorizationServerDocument updatedAuthorizationServer = this.getAuthorizationServerDocumentById(authorizationServerId);
+        return updatedAuthorizationServer.toAuthorizationServerModel();
     }
 
     @Override
-    public AuthorizationServerModel updateAuthorizationServer(String serverId, String serverName, String serverDescription, boolean isActive, List<String> authorizedServerIds) {
-        return null;
+    @CacheEvict(value = "authorizationServerCache", key = "#serverId", beforeInvocation = true)
+    public void updateAuthorizationServer(String serverId, String serverName, String serverDescription, boolean isActive, List<String> authorizedServerIds) {
+        Update updateSpec = new Update();
+        updateSpec.set("authorizationServerName", serverName);
+        updateSpec.set("authorizationServerDescription", serverDescription);
+        updateSpec.set("isActive", isActive);
+        updateSpec.set("authorizedServerIds", authorizedServerIds);
     }
 
     @Override

--- a/hydra/src/main/java/com/heimdallauth/server/services/AuthorizationServerManagementService.java
+++ b/hydra/src/main/java/com/heimdallauth/server/services/AuthorizationServerManagementService.java
@@ -45,12 +45,13 @@ public class AuthorizationServerManagementService {
         return authServerDM.getAuthorizationServerById(serverId);
     }
     public AuthorizationServerModel updateAuthorizationServer(String serverId, AuthorizationServerModel authorizationServerUpdatePayload) {
-        return authServerDM.updateAuthorizationServer(
+        authServerDM.updateAuthorizationServer(
                 serverId,
                 authorizationServerUpdatePayload.getAuthorizationServerName(),
                 authorizationServerUpdatePayload.getAuthorizationServerDescription(),
                 authorizationServerUpdatePayload.isActive(),
                 Collections.emptyList() //TODO remove and properly implement
         );
+        return authServerDM.getAuthorizationServerById(serverId);   //Another step for caching changes
     }
 }


### PR DESCRIPTION
This pull request includes several changes to the `hydra` module, focusing on updating methods in the `AuthorizationServerDataManager` and its MongoDB implementation, as well as adding caching mechanisms. The most important changes include modifying return types, adding cache eviction annotations, and updating the logic for fetching and updating authorization server details.

### Method Updates:
* Changed the return type of `updateAuthorizationServer` from `AuthorizationServerModel` to `void` in `AuthorizationServerDataManager` and its MongoDB implementation. [[1]](diffhunk://#diff-c698436ac2412160b9beeecfb1e2437eb4784b521952694a63e8517e4554e8d0L15-R15) [[2]](diffhunk://#diff-883b18f381e7f6505322eb83f1bc8b0a601a321074ac376cc860b1db25b5f5c4R108-R128)

### Caching Enhancements:
* Added `@CacheEvict` annotations to clear cache entries for `createAuthorizationServer` and `updateSigningKeyId` methods in `AuthorizationServerDataManagerMongoImpl`. [[1]](diffhunk://#diff-883b18f381e7f6505322eb83f1bc8b0a601a321074ac376cc860b1db25b5f5c4R44) [[2]](diffhunk://#diff-883b18f381e7f6505322eb83f1bc8b0a601a321074ac376cc860b1db25b5f5c4R108-R128)

### Logic Improvements:
* Updated the `createAuthorizationServer` method to use `Optional` for fetching and mapping the saved authorization server document.
* Enhanced the `updateSigningKeyId` method to store the old signing key ID before updating to the new one.
* Modified `updateAuthorizationServer` in `AuthorizationServerManagementService` to fetch and return the updated authorization server after performing the update.