### PR TITLE
CRUD changes for Authorization Servers

### DIFF
--- a/commons/src/main/java/com/heimdallauth/server/commons/dto/hydra/CreateAuthorizationServerDTO.java
+++ b/commons/src/main/java/com/heimdallauth/server/commons/dto/hydra/CreateAuthorizationServerDTO.java
@@ -1,0 +1,17 @@
+package com.heimdallauth.server.commons.dto.hydra;
+
+import lombok.*;
+
+import java.util.List;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class CreateAuthorizationServerDTO {
+    private String authorizationServerName;
+    private String authorizationServerDescription;
+    private boolean isActive;
+    private List<String> authorizedServerIds;
+}

--- a/commons/src/main/java/com/heimdallauth/server/commons/models/hydra/AuthorizationServerModel.java
+++ b/commons/src/main/java/com/heimdallauth/server/commons/models/hydra/AuthorizationServerModel.java
@@ -1,0 +1,21 @@
+package com.heimdallauth.server.commons.models.hydra;
+
+import lombok.*;
+
+import java.util.List;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class AuthorizationServerModel {
+    private String id;
+    private String authorizationServerName;
+    private String authorizationServerDescription;
+    private String issueUrl;
+    private String signingKeyId;
+    private boolean isActive;
+    private List<ClientModel> clients;
+    private List<AuthorizationServerModel> authorizedServers;
+}

--- a/commons/src/main/java/com/heimdallauth/server/commons/models/hydra/ClientModel.java
+++ b/commons/src/main/java/com/heimdallauth/server/commons/models/hydra/ClientModel.java
@@ -1,0 +1,14 @@
+package com.heimdallauth.server.commons.models.hydra;
+
+import lombok.*;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class ClientModel {
+    private String id;
+    private String clientName;
+    private String clientDescription;
+}

--- a/hydra/build.gradle
+++ b/hydra/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     implementation 'com.nimbusds:nimbus-jose-jwt:10.0.1'
 //    implementation 'org.springframework.boot:spring-boot-starter-oauth2-authorization-server'
     implementation 'org.springframework.cloud:spring-cloud-starter-consul-discovery'
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'

--- a/hydra/build.gradle
+++ b/hydra/build.gradle
@@ -4,6 +4,10 @@ plugins {
     id 'io.spring.dependency-management' version '1.1.7'
 }
 
+ext {
+    springCloudVersion = "2024.0.0"
+}
+
 group = 'com.heimdallauth.server'
 version = '0.0.1-SNAPSHOT'
 
@@ -25,10 +29,15 @@ repositories {
 
 dependencies {
     implementation project(':commons')
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.3'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+//    implementation 'com.auth0:java-jwt:3.3.0'
+    implementation 'com.nimbusds:nimbus-jose-jwt:10.0.1'
+//    implementation 'org.springframework.boot:spring-boot-starter-oauth2-authorization-server'
+    implementation 'org.springframework.cloud:spring-cloud-starter-consul-discovery'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
@@ -38,6 +47,12 @@ dependencies {
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.testcontainers:mongodb'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:$springCloudVersion"
+    }
 }
 
 tasks.named('test') {

--- a/hydra/src/main/java/com/heimdallauth/server/HydraApplication.java
+++ b/hydra/src/main/java/com/heimdallauth/server/HydraApplication.java
@@ -1,9 +1,12 @@
 package com.heimdallauth.server;
 
+import com.heimdallauth.server.config.HeimdallHydraConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 @SpringBootApplication
+@EnableConfigurationProperties({HeimdallHydraConfiguration.class})
 public class HydraApplication {
 
     public static void main(String[] args) {

--- a/hydra/src/main/java/com/heimdallauth/server/config/HeimdallHydraConfiguration.java
+++ b/hydra/src/main/java/com/heimdallauth/server/config/HeimdallHydraConfiguration.java
@@ -11,5 +11,9 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class HeimdallHydraConfiguration {
     private String domainName;
     private String deploymentName;
+    private String protocol;
 
+    public String getIssuerUrl(String serverId){
+        return String.format("%s://%s.%s/%s", this.protocol, this.deploymentName, this.domainName, serverId);
+    }
 }

--- a/hydra/src/main/java/com/heimdallauth/server/config/HeimdallHydraConfiguration.java
+++ b/hydra/src/main/java/com/heimdallauth/server/config/HeimdallHydraConfiguration.java
@@ -1,0 +1,15 @@
+package com.heimdallauth.server.config;
+
+import lombok.*;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "heimdall.hydra")
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class HeimdallHydraConfiguration {
+    private String domainName;
+    private String deploymentName;
+
+}

--- a/hydra/src/main/java/com/heimdallauth/server/config/SecurityConfig.java
+++ b/hydra/src/main/java/com/heimdallauth/server/config/SecurityConfig.java
@@ -1,0 +1,16 @@
+package com.heimdallauth.server.config;
+
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SecurityConfig {
+//    @Bean
+//    public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
+//        httpSecurity.authorizeHttpRequests(authorizationManagerRequestMatcherRegistry -> {
+//            authorizationManagerRequestMatcherRegistry.requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll();
+//            authorizationManagerRequestMatcherRegistry.requestMatchers("/api/hydra/swagger-ui.html", "/api/hydra/v3/api-docs", "/api/hydra/actuator/**").permitAll();
+//            authorizationManagerRequestMatcherRegistry.anyRequest().authenticated();
+//        });
+//        return httpSecurity.build();
+//    }
+}

--- a/hydra/src/main/java/com/heimdallauth/server/controllers/v1/AuthorizationServerManagementController.java
+++ b/hydra/src/main/java/com/heimdallauth/server/controllers/v1/AuthorizationServerManagementController.java
@@ -1,0 +1,32 @@
+package com.heimdallauth.server.controllers.v1;
+
+import com.heimdallauth.server.commons.dto.hydra.CreateAuthorizationServerDTO;
+import com.heimdallauth.server.commons.models.hydra.AuthorizationServerModel;
+import com.heimdallauth.server.services.AuthorizationServerManagementService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/v1/manage/authorization-servers")
+public class AuthorizationServerManagementController {
+    private final AuthorizationServerManagementService authorizationServerManagementService;
+
+    @Autowired
+    public AuthorizationServerManagementController(AuthorizationServerManagementService authorizationServerManagementService) {
+        this.authorizationServerManagementService = authorizationServerManagementService;
+    }
+
+    @GetMapping("/{serverId}")
+    public ResponseEntity<AuthorizationServerModel> getAuthorizationServerById(@PathVariable("serverId") String serverId) {
+        return ResponseEntity.ok(authorizationServerManagementService.getAuthorizationServerById(serverId));
+    }
+    @PostMapping
+    public ResponseEntity<AuthorizationServerModel> createAuthorizationServer(@RequestBody CreateAuthorizationServerDTO createAuthorizationServerDTO) {
+        return ResponseEntity.ok(authorizationServerManagementService.createAuthorizationServer(createAuthorizationServerDTO));
+    }
+    @PutMapping("/{serverId}")
+    public ResponseEntity<AuthorizationServerModel> updateAuthorizationServer(@PathVariable("serverId") String serverId, @RequestBody AuthorizationServerModel authorizationServerModel) {
+        return ResponseEntity.ok(authorizationServerManagementService.updateAuthorizationServer(serverId, authorizationServerModel));
+    }
+}

--- a/hydra/src/main/java/com/heimdallauth/server/controllers/v1/AuthorizationServerManagementController.java
+++ b/hydra/src/main/java/com/heimdallauth/server/controllers/v1/AuthorizationServerManagementController.java
@@ -7,6 +7,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/v1/manage/authorization-servers")
 public class AuthorizationServerManagementController {
@@ -28,5 +30,9 @@ public class AuthorizationServerManagementController {
     @PutMapping("/{serverId}")
     public ResponseEntity<AuthorizationServerModel> updateAuthorizationServer(@PathVariable("serverId") String serverId, @RequestBody AuthorizationServerModel authorizationServerModel) {
         return ResponseEntity.ok(authorizationServerManagementService.updateAuthorizationServer(serverId, authorizationServerModel));
+    }
+    @GetMapping
+    public ResponseEntity<List<AuthorizationServerModel>> getAllAuthorizationServers(){
+        return ResponseEntity.ok(this.authorizationServerManagementService.getAuthorizationServers());
     }
 }

--- a/hydra/src/main/java/com/heimdallauth/server/datamanagers/AuthorizationServerDataManager.java
+++ b/hydra/src/main/java/com/heimdallauth/server/datamanagers/AuthorizationServerDataManager.java
@@ -10,6 +10,7 @@ public interface AuthorizationServerDataManager {
     List<AuthorizationServerModel> getAuthorizationServers();
     List<AuthorizationServerModel> getActiveAuthorizationServers();
     List<AuthorizationServerModel> getInactiveAuthorizationServers();
+    List<AuthorizationServerModel> getAuthorizationServersByIds(List<String> serverIds);
     AuthorizationServerModel updateAuthorizationServer(String serverId, String serverName, String serverDescription, boolean isActive, List<String> authorizedServerIds);
     void deleteAuthorizationServer(String serverId);
 }

--- a/hydra/src/main/java/com/heimdallauth/server/datamanagers/AuthorizationServerDataManager.java
+++ b/hydra/src/main/java/com/heimdallauth/server/datamanagers/AuthorizationServerDataManager.java
@@ -1,0 +1,15 @@
+package com.heimdallauth.server.datamanagers;
+
+import com.heimdallauth.server.commons.models.hydra.AuthorizationServerModel;
+
+import java.util.List;
+
+public interface AuthorizationServerDataManager {
+    AuthorizationServerModel createAuthorizationServer(String serverName, String serverDescription, boolean isActive, List<String> authorizedServerIds);
+    AuthorizationServerModel getAuthorizationServerById(String serverId);
+    List<AuthorizationServerModel> getAuthorizationServers();
+    List<AuthorizationServerModel> getActiveAuthorizationServers();
+    List<AuthorizationServerModel> getInactiveAuthorizationServers();
+    AuthorizationServerModel updateAuthorizationServer(String serverId, String serverName, String serverDescription, boolean isActive, List<String> authorizedServerIds);
+    void deleteAuthorizationServer(String serverId);
+}

--- a/hydra/src/main/java/com/heimdallauth/server/datamanagers/impl/mongodb/AuthorizationServerDataManagerMongoImpl.java
+++ b/hydra/src/main/java/com/heimdallauth/server/datamanagers/impl/mongodb/AuthorizationServerDataManagerMongoImpl.java
@@ -1,0 +1,74 @@
+package com.heimdallauth.server.datamanagers.impl.mongodb;
+
+import com.heimdallauth.server.commons.models.hydra.AuthorizationServerModel;
+import com.heimdallauth.server.config.HeimdallHydraConfiguration;
+import com.heimdallauth.server.datamanagers.AuthorizationServerDataManager;
+import com.heimdallauth.server.documents.AuthorizationServerDocument;
+import com.heimdallauth.server.utils.RandomIdGeneratorUtil;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public class AuthorizationServerDataManagerMongoImpl implements AuthorizationServerDataManager {
+    private final MongoTemplate mongoTemplate;
+    private final HeimdallHydraConfiguration heimdallHydraConfiguration;
+
+    @Autowired
+    public AuthorizationServerDataManagerMongoImpl(MongoTemplate mongoTemplate, HeimdallHydraConfiguration heimdallHydraConfiguration) {
+        this.mongoTemplate = mongoTemplate;
+        this.heimdallHydraConfiguration = heimdallHydraConfiguration;
+    }
+
+    @Override
+    public AuthorizationServerModel createAuthorizationServer(String serverName, String serverDescription, boolean isActive, List<String> authorizedServerIds) {
+        AuthorizationServerDocument authorizationServerDocument = AuthorizationServerDocument.builder()
+                .id(RandomIdGeneratorUtil.generateRandomServerId())
+                .authorizationServerName(serverName)
+                .authorizationServerDescription(serverDescription)
+                .issueUrl(heimdallHydraConfiguration.getDeploymentName() + heimdallHydraConfiguration.getDomainName() + "/oauth2/token")
+                .isActive(isActive)
+                .authorizedServerIds(authorizedServerIds)
+                .build();
+        return mongoTemplate.save(authorizationServerDocument).toAuthorizationServerModel();
+    }
+
+    @Override
+    public AuthorizationServerModel getAuthorizationServerById(String serverId) {
+        Query query = new Query();
+        query.addCriteria(Criteria.where("id").is(serverId));
+        AuthorizationServerDocument authorizationServerDocument = Optional.ofNullable(mongoTemplate.findOne(query, AuthorizationServerDocument.class)).orElseThrow(() -> new RuntimeException("Authorization Server not found"));
+        return null;
+    }
+
+    @Override
+    public List<AuthorizationServerModel> getAuthorizationServers() {
+        return List.of();
+    }
+
+    @Override
+    public List<AuthorizationServerModel> getActiveAuthorizationServers() {
+        return List.of();
+    }
+
+    @Override
+    public List<AuthorizationServerModel> getInactiveAuthorizationServers() {
+        return List.of();
+    }
+
+    @Override
+    public AuthorizationServerModel updateAuthorizationServer(String serverId, String serverName, String serverDescription, boolean isActive, List<String> authorizedServerIds) {
+        return null;
+    }
+
+    @Override
+    public void deleteAuthorizationServer(String serverId) {
+
+    }
+}

--- a/hydra/src/main/java/com/heimdallauth/server/datamanagers/impl/mongodb/AuthorizationServerDataManagerMongoImpl.java
+++ b/hydra/src/main/java/com/heimdallauth/server/datamanagers/impl/mongodb/AuthorizationServerDataManagerMongoImpl.java
@@ -39,11 +39,12 @@ public class AuthorizationServerDataManagerMongoImpl implements AuthorizationSer
     }
     @Override
     public AuthorizationServerModel createAuthorizationServer(String serverName, String serverDescription, boolean isActive, List<String> authorizedServerIds) {
+        String serverId = RandomIdGeneratorUtil.generateRandomServerId();
         AuthorizationServerDocument authorizationServerDocument = AuthorizationServerDocument.builder()
-                .id(RandomIdGeneratorUtil.generateRandomServerId())
+                .id(serverId)
                 .authorizationServerName(serverName)
                 .authorizationServerDescription(serverDescription)
-                .issueUrl(heimdallHydraConfiguration.getDeploymentName() + heimdallHydraConfiguration.getDomainName() + "/oauth2/token")
+                .issueUrl(heimdallHydraConfiguration.getIssuerUrl(serverId))
                 .isActive(isActive)
                 .authorizedServerIds(authorizedServerIds)
                 .build();
@@ -55,7 +56,7 @@ public class AuthorizationServerDataManagerMongoImpl implements AuthorizationSer
     public AuthorizationServerModel getAuthorizationServerById(String serverId) {
         Query query = new Query();
         query.addCriteria(Criteria.where("id").is(serverId));
-        AuthorizationServerDocument authorizationServerDocument = Optional.ofNullable(mongoTemplate.findOne(query, AuthorizationServerDocument.class)).orElseThrow(() -> new RuntimeException("Authorization Server not found"));
+        AuthorizationServerDocument authorizationServerDocument = Optional.ofNullable(mongoTemplate.findOne(query, AuthorizationServerDocument.class, AUTHORIZATION_SERVERS_COLLECTION_NAME)).orElseThrow(() -> new RuntimeException("Authorization Server not found"));
         return authorizationServerDocument.toAuthorizationServerModel();
     }
 

--- a/hydra/src/main/java/com/heimdallauth/server/datamanagers/impl/mongodb/MongoBulkOperationsDAOService.java
+++ b/hydra/src/main/java/com/heimdallauth/server/datamanagers/impl/mongodb/MongoBulkOperationsDAOService.java
@@ -1,0 +1,44 @@
+package com.heimdallauth.server.datamanagers.impl.mongodb;
+
+import com.mongodb.client.result.DeleteResult;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.stereotype.Service;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+@Service
+@Slf4j
+public class MongoBulkOperationsDAOService {
+    private final MongoTemplate mongoTemplate;
+
+    public MongoBulkOperationsDAOService(MongoTemplate mongoTemplate) {
+        this.mongoTemplate = mongoTemplate;
+    }
+    protected  <T> List<String> executeMongoDBSaveOperation(List<T> objectCollection, String collectionName) {
+        Collection<T> savedCollection = this.mongoTemplate.insert(objectCollection, collectionName);
+        List<String> savedCollectionIds = new ArrayList<>();
+        log.debug("Saved {} objects to MongoDB collection {}", savedCollection.size(), collectionName);
+
+        if (!savedCollection.isEmpty()) {
+            try {
+                Method getIdMethod = savedCollection.iterator().next().getClass().getMethod("getId");
+                for (T document : savedCollection) {
+                    savedCollectionIds.add((String) getIdMethod.invoke(document));
+                }
+            } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+                log.error("Error retrieving IDs from saved documents", e);
+            }
+        }
+
+        return savedCollectionIds;
+    }
+    protected  DeleteResult executeBulkMongoDeleteOperation(Query documentSelectionQuery, String collectionName){
+        return this.mongoTemplate.remove(documentSelectionQuery, collectionName);
+    }
+}

--- a/hydra/src/main/java/com/heimdallauth/server/documents/AuthorizationServerDocument.java
+++ b/hydra/src/main/java/com/heimdallauth/server/documents/AuthorizationServerDocument.java
@@ -1,0 +1,35 @@
+package com.heimdallauth.server.documents;
+
+import com.heimdallauth.server.commons.models.hydra.AuthorizationServerModel;
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.List;
+
+@Document
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class AuthorizationServerDocument {
+    @Id
+    private String id;
+    private String authorizationServerName;
+    private String authorizationServerDescription;
+    private String issueUrl;
+    private String signingKeyId;
+    private boolean isActive;
+    private List<String> authorizedServerIds;
+
+    public AuthorizationServerModel toAuthorizationServerModel() {
+        return AuthorizationServerModel.builder()
+                .id(this.getId())
+                .authorizationServerName(this.getAuthorizationServerName())
+                .authorizationServerDescription(this.getAuthorizationServerDescription())
+                .issueUrl(this.getIssueUrl())
+                .isActive(this.isActive())
+                .build();
+    }
+}

--- a/hydra/src/main/java/com/heimdallauth/server/services/AuthorizationServerManagementService.java
+++ b/hydra/src/main/java/com/heimdallauth/server/services/AuthorizationServerManagementService.java
@@ -1,0 +1,50 @@
+package com.heimdallauth.server.services;
+
+import com.heimdallauth.server.commons.dto.hydra.CreateAuthorizationServerDTO;
+import com.heimdallauth.server.commons.models.hydra.AuthorizationServerModel;
+import com.heimdallauth.server.datamanagers.AuthorizationServerDataManager;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.List;
+
+@Service
+@Slf4j
+public class AuthorizationServerManagementService {
+    private final AuthorizationServerDataManager authServerDM;
+
+    public AuthorizationServerManagementService(AuthorizationServerDataManager authServerDM) {
+        this.authServerDM = authServerDM;
+    }
+
+    public AuthorizationServerModel createAuthorizationServer(CreateAuthorizationServerDTO authorizationServerCreatePayload) {
+        return authServerDM.createAuthorizationServer(
+                authorizationServerCreatePayload.getAuthorizationServerName(),
+                authorizationServerCreatePayload.getAuthorizationServerDescription(),
+                authorizationServerCreatePayload.isActive(),
+                authorizationServerCreatePayload.getAuthorizedServerIds()
+        );
+    }
+    public List<AuthorizationServerModel> getAuthorizationServers() {
+        return authServerDM.getAuthorizationServers();
+    }
+    public List<AuthorizationServerModel> getActiveAuthorizationServers() {
+        return authServerDM.getActiveAuthorizationServers();
+    }
+    public List<AuthorizationServerModel> getInactiveAuthorizationServers() {
+        return authServerDM.getInactiveAuthorizationServers();
+    }
+    public AuthorizationServerModel getAuthorizationServerById(String serverId) {
+        return authServerDM.getAuthorizationServerById(serverId);
+    }
+    public AuthorizationServerModel updateAuthorizationServer(String serverId, AuthorizationServerModel authorizationServerUpdatePayload) {
+        return authServerDM.updateAuthorizationServer(
+                serverId,
+                authorizationServerUpdatePayload.getAuthorizationServerName(),
+                authorizationServerUpdatePayload.getAuthorizationServerDescription(),
+                authorizationServerUpdatePayload.isActive(),
+                Collections.emptyList() //TODO remove and properly implement
+        );
+    }
+}

--- a/hydra/src/main/java/com/heimdallauth/server/utils/RandomIdGeneratorUtil.java
+++ b/hydra/src/main/java/com/heimdallauth/server/utils/RandomIdGeneratorUtil.java
@@ -1,0 +1,28 @@
+package com.heimdallauth.server.utils;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+@Slf4j
+public class RandomIdGeneratorUtil {
+    private static final String RANDOMIZATION_ALGORITHM = "SHA1PRNG";
+    private static final String CHARSET = "0123456789abcdefghijklmnopqrstuvwxyz";
+    private static final int ID_LENGTH = 32;
+    private static SecureRandom RANDOM;
+    static {
+        try{
+            RANDOM = SecureRandom.getInstance(RANDOMIZATION_ALGORITHM);
+        }catch (NoSuchAlgorithmException e){
+            log.error("Error while creating random id generator", e);
+        }
+    }
+
+    public static String generateRandomServerId(){
+        StringBuilder stringBuilder = new StringBuilder();
+        for(int i = 0; i < ID_LENGTH; i++){
+            stringBuilder.append(CHARSET.charAt(RANDOM.nextInt(CHARSET.length())));
+        }
+        return stringBuilder.toString();
+    }
+}

--- a/hydra/src/main/resources/application-local.yml
+++ b/hydra/src/main/resources/application-local.yml
@@ -6,6 +6,6 @@ spring:
       host: localhost
       port: 6379
     mongodb:
-      uri:
+      uri: mongodb://${MONGO_USERNAME}:${MONGO_PASSWORD}@${MONGO_HOST}:${MONGO_PORT}/${DB_NAME}?authSource=admin
 server:
   port: 0

--- a/hydra/src/main/resources/application.yml
+++ b/hydra/src/main/resources/application.yml
@@ -10,5 +10,11 @@ spring:
     consul:
       discovery:
         health-check-path: /api/hydra/actuator/health
+server:
   servlet:
     context-path: /api/hydra
+heimdall:
+  hydra:
+    domain-name: heimdallauth.com
+    deployment-name: purpleid
+    protocol: https

--- a/hydra/src/main/resources/application.yml
+++ b/hydra/src/main/resources/application.yml
@@ -1,3 +1,14 @@
 spring:
   application:
     name: hydra
+  security:
+    user:
+      name: admin
+      password: admin
+
+  cloud:
+    consul:
+      discovery:
+        health-check-path: /api/hydra/actuator/health
+  servlet:
+    context-path: /api/hydra

--- a/jfk-gateway/src/main/resources/application.yml
+++ b/jfk-gateway/src/main/resources/application.yml
@@ -13,3 +13,7 @@ spring:
             uri: lb://bifrost
             predicates:
               - Path=/api/bifrost/**
+          - id: hydra
+            uri: lb://hydra
+            predicates:
+              - Path=/api/hydra/**


### PR DESCRIPTION
This pull request introduces several new features and enhancements to the Hydra authorization server, including the addition of DTOs, models, controllers, and configuration classes. The changes focus on creating and managing authorization servers, integrating with MongoDB, and updating the build configuration.

### New Features and Enhancements:

* **DTOs and Models:**
  - Added `CreateAuthorizationServerDTO` to represent the data transfer object for creating authorization servers.
  - Added `AuthorizationServerModel` and `ClientModel` to represent the authorization server and client entities, respectively. [[1]](diffhunk://#diff-d6ca1ba65d035b20d2bf980c656037f3de23e6bcae491192a6d63f1961764159R1-R21) [[2]](diffhunk://#diff-817f414ecf7a5227bce9e1584e73fc62f6f3bee1c974123f7cbbea060c246f1aR1-R14)

* **Controllers and Services:**
  - Introduced `AuthorizationServerManagementController` to handle API requests for managing authorization servers.
  - Added `AuthorizationServerManagementService` to provide business logic for managing authorization servers.

* **Data Management:**
  - Created `AuthorizationServerDataManager` interface and its MongoDB implementation `AuthorizationServerDataManagerMongoImpl` to handle data operations for authorization servers. [[1]](diffhunk://#diff-c698436ac2412160b9beeecfb1e2437eb4784b521952694a63e8517e4554e8d0R1-R16) [[2]](diffhunk://#diff-883b18f381e7f6505322eb83f1bc8b0a601a321074ac376cc860b1db25b5f5c4R1-R106)
  - Added `MongoBulkOperationsDAOService` to support bulk operations in MongoDB.
  - Introduced `AuthorizationServerDocument` to map authorization server data to MongoDB documents.

* **Configuration and Utilities:**
  - Added `HeimdallHydraConfiguration` to manage configuration properties for Hydra.
  - Created `SecurityConfig` for security-related configurations.
  - Implemented `RandomIdGeneratorUtil` for generating random server IDs.

* **Build Configuration:**
  - Updated `build.gradle` to include new dependencies and manage Spring Cloud versions. [[1]](diffhunk://#diff-2a59e800745eaca879781e080041fd3ec1ff233693ee4dee18cb6ad927a9e51eR7-R10) [[2]](diffhunk://#diff-2a59e800745eaca879781e080041fd3ec1ff233693ee4dee18cb6ad927a9e51eR32-R41) [[3]](diffhunk://#diff-2a59e800745eaca879781e080041fd3ec1ff233693ee4dee18cb6ad927a9e51eR53-R58)
  - Enabled configuration properties in `HydraApplication`.

These changes collectively enhance the functionality of the Hydra authorization server by adding comprehensive support for managing authorization servers and integrating with MongoDB for data persistence.